### PR TITLE
feat: harden league scoring and replay validation

### DIFF
--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -211,6 +211,8 @@ CREATE TABLE event_session_round_team_results (
   round_id INTEGER NOT NULL REFERENCES event_session_rounds(id) ON DELETE CASCADE,
   team_no INTEGER NOT NULL CHECK (team_no > 0),
   score INTEGER NOT NULL,
+  end_condition INTEGER,
+  bottom_deck_risk NUMERIC(8, 3),
   replay_game_id BIGINT,
   submitted_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
   submitted_at TIMESTAMPTZ DEFAULT NOW(),

--- a/apps/api/src/modules/events/event.routes.ts
+++ b/apps/api/src/modules/events/event.routes.ts
@@ -35,6 +35,11 @@ import { pool } from '../../config/db';
 import { listTeamMembers } from '../teams/team.service';
 import { validateSlug } from '../../utils/slug';
 import { getErrorCode, getErrorDetail, isAdminUser, validateLength } from './event.routes.helpers';
+import {
+  extractReplayExportPlayers,
+  extractReplayHistoryGames,
+  normalizeReplayEndCondition,
+} from '../replay/replay-parse';
 
 const router = Router();
 
@@ -652,7 +657,7 @@ router.post(
       step = 'lookup template';
       const tplResult = await pool.query(
         `
-      SELECT egt.id, egt.seed_payload, egt.variant, es.event_id
+      SELECT egt.id, egt.seed_payload, egt.variant, es.event_id, es.config_json
       FROM event_game_templates egt
       JOIN event_stages es ON es.event_stage_id = egt.event_stage_id
       WHERE egt.id = $1;
@@ -667,6 +672,7 @@ router.post(
         seed_payload: string | null;
         variant: string;
         event_id: number;
+        config_json: unknown;
       };
       if (tpl.event_id !== eventId) {
         return res.status(400).json({ error: 'Template does not belong to this event' });
@@ -674,8 +680,17 @@ router.post(
       console.log('[validate-replay] template', { tpl });
 
       const members = await listTeamMembers(team.id);
-      const memberNames = members.map((m) => m.display_name);
-      console.log('[validate-replay] members', memberNames);
+      const teamPlayerPool = members
+        .filter((m) => m.role === 'PLAYER')
+        .map((m) => m.display_name);
+      const stageConfig =
+        tpl.config_json && typeof tpl.config_json === 'object' && !Array.isArray(tpl.config_json)
+          ? (tpl.config_json as { enforce_exact_team_size?: unknown })
+          : {};
+      const enforceExactTeamMatch = stageConfig.enforce_exact_team_size === true;
+      console.log('[validate-replay] members', teamPlayerPool, {
+        enforceExactTeamMatch,
+      });
 
       // Stage 1: fetch export and validate players/seed/size
       step = 'fetch export';
@@ -688,16 +703,36 @@ router.post(
       if (!exportJson || typeof exportJson !== 'object') {
         return res.status(400).json({ error: 'Invalid export payload from hanab.live' });
       }
-      const exportPlayers =
-        exportJson.players ?? exportJson.playerNames ?? exportJson.player_names ?? [];
+      const exportPlayers = extractReplayExportPlayers(exportJson);
+      if (!exportPlayers || exportPlayers.length === 0) {
+        return res.status(400).json({ error: 'Replay export is missing a valid players list' });
+      }
       const seedString = exportJson.seed ?? '';
 
-      // Check players subset
-      const missingPlayers = exportPlayers.filter((p) => !memberNames.includes(p));
-      if (missingPlayers.length > 0) {
+      const duplicatePlayers = exportPlayers.filter(
+        (player) =>
+          exportPlayers.findIndex((candidate: string) => candidate === player) !==
+          exportPlayers.lastIndexOf(player),
+      );
+      if (duplicatePlayers.length > 0) {
         return res.status(400).json({
-          error: `Replay includes players not on this team: ${missingPlayers.join(', ')}`,
+          error: `Replay includes duplicate players: ${[...new Set(duplicatePlayers)].join(', ')}`,
         });
+      }
+
+      const nonPoolPlayers = exportPlayers.filter((p) => !teamPlayerPool.includes(p));
+      if (nonPoolPlayers.length > 0) {
+        return res.status(400).json({
+          error: `Replay includes players not in this team pool: ${nonPoolPlayers.join(', ')}`,
+        });
+      }
+      if (enforceExactTeamMatch) {
+        const missingPlayers = teamPlayerPool.filter((p) => !exportPlayers.includes(p));
+        if (missingPlayers.length > 0 || exportPlayers.length !== teamPlayerPool.length) {
+          return res.status(400).json({
+            error: `Replay team must exactly match registered team players: ${teamPlayerPool.join(', ')}`,
+          });
+        }
       }
 
       // Check seed and player count from seed string
@@ -741,13 +776,7 @@ router.post(
       let playedAt: string | null = null;
 
       // history-full returns an array for single-user queries. For multi-user it can be {games: []}
-      const historyGames: ReplayHistoryGame[] = Array.isArray(historyData)
-        ? (historyData as ReplayHistoryGame[])
-        : historyData &&
-            typeof historyData === 'object' &&
-            Array.isArray((historyData as { games?: unknown }).games)
-          ? ((historyData as { games: ReplayHistoryGame[] }).games ?? [])
-          : [];
+      const historyGames = extractReplayHistoryGames<ReplayHistoryGame>(historyData);
 
       if (historyGames.length > 0) {
         const game = historyGames.find(
@@ -767,7 +796,7 @@ router.post(
           };
           flagsOk = Object.values(flags).every((v) => v === false || v === undefined);
           score = game.score == null ? null : Number(game.score);
-          endCondition = game.endCondition ?? null;
+          endCondition = normalizeReplayEndCondition(game.endCondition);
           playedAt =
             game.datetimeFinished ?? game.datetimeFinishedUtc ?? game.datetime_finished ?? null;
         }

--- a/apps/api/src/modules/events/event.routes.ts
+++ b/apps/api/src/modules/events/event.routes.ts
@@ -680,9 +680,7 @@ router.post(
       console.log('[validate-replay] template', { tpl });
 
       const members = await listTeamMembers(team.id);
-      const teamPlayerPool = members
-        .filter((m) => m.role === 'PLAYER')
-        .map((m) => m.display_name);
+      const teamPlayerPool = members.filter((m) => m.role === 'PLAYER').map((m) => m.display_name);
       const stageConfig =
         tpl.config_json && typeof tpl.config_json === 'object' && !Array.isArray(tpl.config_json)
           ? (tpl.config_json as { enforce_exact_team_size?: unknown })

--- a/apps/api/src/modules/replay/replay-parse.ts
+++ b/apps/api/src/modules/replay/replay-parse.ts
@@ -32,4 +32,3 @@ export function normalizeReplayEndCondition(value: unknown): number | null {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
 }
-

--- a/apps/api/src/modules/replay/replay-parse.ts
+++ b/apps/api/src/modules/replay/replay-parse.ts
@@ -1,0 +1,35 @@
+export type ReplayHistoryGameLike = {
+  id?: string | number | null;
+  gameId?: string | number | null;
+  game_id?: string | number | null;
+};
+
+export function extractReplayExportPlayers(payload: unknown): string[] | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const candidate =
+    (payload as { players?: unknown }).players ??
+    (payload as { playerNames?: unknown }).playerNames ??
+    (payload as { player_names?: unknown }).player_names;
+  if (!Array.isArray(candidate)) return null;
+  if (!candidate.every((value) => typeof value === 'string' && value.trim().length > 0)) {
+    return null;
+  }
+  return candidate as string[];
+}
+
+export function extractReplayHistoryGames<T = ReplayHistoryGameLike>(payload: unknown): T[] {
+  if (Array.isArray(payload)) return payload as T[];
+  if (payload && typeof payload === 'object') {
+    const objectPayload = payload as { games?: unknown; rows?: unknown };
+    if (Array.isArray(objectPayload.games)) return objectPayload.games as T[];
+    if (Array.isArray(objectPayload.rows)) return objectPayload.rows as T[];
+  }
+  return [];
+}
+
+export function normalizeReplayEndCondition(value: unknown): number | null {
+  if (value == null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+

--- a/apps/api/src/modules/session-ladder/session-ladder.end-condition.ts
+++ b/apps/api/src/modules/session-ladder/session-ladder.end-condition.ts
@@ -1,0 +1,16 @@
+export const END_CONDITION_NAMES: Record<number, string> = {
+  0: 'In Progress',
+  1: 'Perfect',
+  2: 'Strike Out',
+  3: 'Time Out',
+  4: 'Terminated By Player',
+  5: 'Speedrun Fail',
+  6: 'Idle Timeout',
+  7: 'Character Softlock',
+  8: 'All Or Nothing Fail',
+  9: 'All Or Nothing Softlock',
+  10: 'Terminated By Vote',
+};
+
+export const END_CONDITIONS_TURNS_VICTORY = new Set<number>([3, 4, 10]);
+

--- a/apps/api/src/modules/session-ladder/session-ladder.end-condition.ts
+++ b/apps/api/src/modules/session-ladder/session-ladder.end-condition.ts
@@ -13,4 +13,3 @@ export const END_CONDITION_NAMES: Record<number, string> = {
 };
 
 export const END_CONDITIONS_TURNS_VICTORY = new Set<number>([3, 4, 10]);
-

--- a/apps/api/src/modules/session-ladder/session-ladder.routes.ts
+++ b/apps/api/src/modules/session-ladder/session-ladder.routes.ts
@@ -41,6 +41,11 @@ import {
   parseGameId,
   parseSeedPayload,
 } from './session-ladder.utils';
+import {
+  extractReplayExportPlayers,
+  extractReplayHistoryGames,
+  normalizeReplayEndCondition,
+} from '../replay/replay-parse';
 
 const router = Router();
 
@@ -57,6 +62,9 @@ type ReplayHistoryGame = {
   score?: number | string | null;
   endCondition?: number | null;
   datetimeStarted?: string | null;
+  datetimeFinished?: string | null;
+  datetimeFinishedUtc?: string | null;
+  datetime_finished?: string | null;
 };
 
 async function requireSessionLadderEvent(slug: string, res: Response) {
@@ -614,8 +622,14 @@ router.post(
     const teamNo = Number(req.body?.team_no);
     const score = Number(req.body?.score);
     const replayGameIdRaw = req.body?.replay_game_id;
+    const endConditionRaw = req.body?.end_condition;
+    const bottomDeckRiskRaw = req.body?.bottom_deck_risk;
     const replayGameId =
       replayGameIdRaw == null || replayGameIdRaw === '' ? null : Number(replayGameIdRaw);
+    const endCondition =
+      endConditionRaw == null || endConditionRaw === '' ? null : Number(endConditionRaw);
+    const bottomDeckRisk =
+      bottomDeckRiskRaw == null || bottomDeckRiskRaw === '' ? null : Number(bottomDeckRiskRaw);
     if (!Number.isInteger(roundId) || roundId <= 0) {
       return res.status(400).json({ error: 'Invalid roundId' });
     }
@@ -629,6 +643,14 @@ router.post(
       return res
         .status(400)
         .json({ error: 'replay_game_id must be a positive integer when provided' });
+    }
+    if (endCondition != null && !Number.isInteger(endCondition)) {
+      return res.status(400).json({ error: 'end_condition must be an integer when provided' });
+    }
+    if (bottomDeckRisk != null && (!Number.isFinite(bottomDeckRisk) || bottomDeckRisk < 0)) {
+      return res
+        .status(400)
+        .json({ error: 'bottom_deck_risk must be a non-negative number when provided' });
     }
 
     const eventId = await getRoundEventId(roundId);
@@ -659,6 +681,8 @@ router.post(
       score,
       submittedByUserId: req.user!.userId,
       replayGameId,
+      endCondition,
+      bottomDeckRisk,
     });
     res.status(201).json(row);
   },
@@ -725,16 +749,31 @@ router.post(
         return res.status(400).json({ error: 'Invalid export payload from hanab.live' });
       }
 
-      const exportPlayers = (exportJson.players ??
-        exportJson.playerNames ??
-        exportJson.player_names ??
-        []) as string[];
+      const exportPlayers = extractReplayExportPlayers(exportJson);
+      if (!exportPlayers || exportPlayers.length === 0) {
+        return res.status(400).json({ error: 'Replay export is missing a valid players list' });
+      }
       const seedString = String(exportJson.seed ?? '');
+      const expectedPlayers = context.team_players;
+      const duplicatePlayers = exportPlayers.filter(
+        (player, index) => exportPlayers.indexOf(player) !== index,
+      );
+      if (duplicatePlayers.length > 0) {
+        return res.status(400).json({
+          error: `Replay includes duplicate players: ${[...new Set(duplicatePlayers)].join(', ')}`,
+        });
+      }
 
-      const unexpectedPlayers = exportPlayers.filter((p) => !context.team_players.includes(p));
+      const unexpectedPlayers = exportPlayers.filter((p) => !expectedPlayers.includes(p));
       if (unexpectedPlayers.length > 0) {
         return res.status(400).json({
           error: `Replay includes players not on this team: ${unexpectedPlayers.join(', ')}`,
+        });
+      }
+      const missingPlayers = expectedPlayers.filter((p) => !exportPlayers.includes(p));
+      if (missingPlayers.length > 0 || exportPlayers.length !== expectedPlayers.length) {
+        return res.status(400).json({
+          error: `Replay team must exactly match assigned players: ${expectedPlayers.join(', ')}`,
         });
       }
 
@@ -757,11 +796,7 @@ router.post(
         `https://hanab.live/api/v1/history-full/${encodeURIComponent(context.team_players[0])}?start=${gameId}&end=${gameId}`,
       );
 
-      const historyGames = Array.isArray(historyData)
-        ? historyData
-        : Array.isArray(historyData?.games)
-          ? historyData.games
-          : [];
+      const historyGames = extractReplayHistoryGames<ReplayHistoryGame>(historyData);
       const game = historyGames.find(
         (g: ReplayHistoryGame) => String(g.id ?? g.gameId ?? g.game_id) === String(gameId),
       );
@@ -784,6 +819,8 @@ router.post(
         return res.status(400).json({ error: 'Unable to derive score from replay' });
       }
 
+      const endCondition = normalizeReplayEndCondition(game.endCondition);
+
       return res.json({
         ok: true,
         gameId,
@@ -794,7 +831,7 @@ router.post(
         derived: {
           variant: replayVariantRaw ?? expected.variant,
           score,
-          endCondition: game.endCondition ?? null,
+          endCondition,
           playedAt:
             game.datetimeFinished ?? game.datetimeFinishedUtc ?? game.datetime_finished ?? null,
         },

--- a/apps/api/src/modules/session-ladder/session-ladder.service.ts
+++ b/apps/api/src/modules/session-ladder/session-ladder.service.ts
@@ -1,6 +1,7 @@
 import { pool } from '../../config/db';
 import { partitionHybrid34, shuffleInPlace } from './session-ladder.assignment';
 import type { PoolClient } from 'pg';
+import { END_CONDITIONS_TURNS_VICTORY } from './session-ladder.end-condition';
 
 export type SessionLadderConfig = {
   event_id: number;
@@ -76,8 +77,28 @@ export type SessionEloRow = {
 };
 
 let readyCheckTablesEnsured = false;
-let roundResultReplayColumnEnsured = false;
+let roundResultMetadataColumnsEnsured = false;
 const readyCheckFinalizeTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+export type VictoryType = 'score' | 'bottom_deck_risk' | 'turns';
+
+const K_FACTOR_MATRIX: Record<2 | 3 | 4, Record<VictoryType, number>> = {
+  2: {
+    score: 48,
+    bottom_deck_risk: 32,
+    turns: 16,
+  },
+  3: {
+    score: 30,
+    bottom_deck_risk: 20,
+    turns: 10,
+  },
+  4: {
+    score: 24,
+    bottom_deck_risk: 16,
+    turns: 8,
+  },
+};
 
 async function ensureReadyCheckTables(): Promise<void> {
   if (readyCheckTablesEnsured) return;
@@ -104,13 +125,101 @@ async function ensureReadyCheckTables(): Promise<void> {
   readyCheckTablesEnsured = true;
 }
 
-async function ensureRoundResultReplayColumn(): Promise<void> {
-  if (roundResultReplayColumnEnsured) return;
+async function ensureRoundResultMetadataColumns(): Promise<void> {
+  if (roundResultMetadataColumnsEnsured) return;
   await pool.query(`
     ALTER TABLE event_session_round_team_results
     ADD COLUMN IF NOT EXISTS replay_game_id BIGINT NULL
   `);
-  roundResultReplayColumnEnsured = true;
+  await pool.query(`
+    ALTER TABLE event_session_round_team_results
+    ADD COLUMN IF NOT EXISTS end_condition INTEGER NULL
+  `);
+  await pool.query(`
+    ALTER TABLE event_session_round_team_results
+    ADD COLUMN IF NOT EXISTS bottom_deck_risk NUMERIC(8, 3) NULL
+  `);
+  roundResultMetadataColumnsEnsured = true;
+}
+
+function resolveTeamCountBucket(teamCount: number): 2 | 3 | 4 {
+  if (teamCount <= 2) return 2;
+  if (teamCount === 3) return 3;
+  return 4;
+}
+
+export function classifyVictoryType(input: {
+  endCondition: number | null;
+  bottomDeckRisk: number | null;
+}): VictoryType {
+  const { endCondition, bottomDeckRisk } = input;
+  if (bottomDeckRisk != null) {
+    return 'bottom_deck_risk';
+  }
+  if (endCondition != null && END_CONDITIONS_TURNS_VICTORY.has(endCondition)) {
+    return 'turns';
+  }
+  return 'score';
+}
+
+export function resolveRoundPairwiseKFactor(input: {
+  teamCount: number;
+  defaultK: number;
+  endCondition: number | null;
+  bottomDeckRisk: number | null;
+}): number {
+  const { teamCount, defaultK, endCondition, bottomDeckRisk } = input;
+  if (teamCount < 2) return defaultK;
+  const teamBucket = resolveTeamCountBucket(teamCount);
+  const victoryType = classifyVictoryType({ endCondition, bottomDeckRisk });
+  return K_FACTOR_MATRIX[teamBucket][victoryType] ?? defaultK;
+}
+
+export type EloTeamInput = {
+  team_no: number;
+  score: number;
+  avg_rating: number;
+  end_condition: number | null;
+  bottom_deck_risk: number | null;
+};
+
+export type EloTeamDelta = {
+  team_no: number;
+  delta: number;
+  k_used: number;
+  victory_type: VictoryType;
+};
+
+export function computeTeamCompetitiveDeltas(input: {
+  teams: EloTeamInput[];
+  defaultK: number;
+}): EloTeamDelta[] {
+  const { teams, defaultK } = input;
+  const teamCount = teams.length;
+  return teams.map((a) => {
+    const kUsed = resolveRoundPairwiseKFactor({
+      teamCount,
+      defaultK,
+      endCondition: a.end_condition ?? null,
+      bottomDeckRisk: a.bottom_deck_risk ?? null,
+    });
+    let sum = 0;
+    for (const b of teams) {
+      if (a.team_no === b.team_no) continue;
+      const expected = 1 / (1 + 10 ** ((b.avg_rating - a.avg_rating) / 400));
+      const actual = a.score > b.score ? 1 : a.score < b.score ? 0 : 0.5;
+      sum += actual - expected;
+    }
+    return {
+      team_no: a.team_no,
+      delta: kUsed * sum,
+      k_used: kUsed,
+      victory_type: classifyVictoryType({
+        endCondition: a.end_condition ?? null,
+        bottomDeckRisk: a.bottom_deck_risk ?? null,
+      }),
+    };
+  });
 }
 
 async function finalizeActiveRoundsWithForfeitsTx(
@@ -813,7 +922,7 @@ export async function setSessionPresence(input: {
 
 export async function getSessionState(sessionId: number) {
   await ensureReadyCheckTables();
-  await ensureRoundResultReplayColumn();
+  await ensureRoundResultMetadataColumns();
   try {
     const readyCheckStatus = await pool.query<{ status: 'open' | 'closed'; ends_at: string }>(
       `
@@ -916,9 +1025,19 @@ export async function getSessionState(sessionId: number) {
     submitted_at: string;
     submitted_by_user_id: number | null;
     replay_game_id: string | null;
+    end_condition: number | null;
+    bottom_deck_risk: number | null;
   }>(
     `
-    SELECT round_id, team_no, score, submitted_at, submitted_by_user_id, replay_game_id::text
+    SELECT
+      round_id,
+      team_no,
+      score,
+      submitted_at,
+      submitted_by_user_id,
+      replay_game_id::text,
+      end_condition,
+      bottom_deck_risk::float8 AS bottom_deck_risk
     FROM event_session_round_team_results
     WHERE round_id IN (
       SELECT id FROM event_session_rounds WHERE session_id = $1
@@ -1637,9 +1756,19 @@ export async function submitRoundScore(input: {
   score: number;
   submittedByUserId: number;
   replayGameId?: number | null;
+  endCondition?: number | null;
+  bottomDeckRisk?: number | null;
 }) {
-  await ensureRoundResultReplayColumn();
-  const { roundId, teamNo, score, submittedByUserId, replayGameId = null } = input;
+  await ensureRoundResultMetadataColumns();
+  const {
+    roundId,
+    teamNo,
+    score,
+    submittedByUserId,
+    replayGameId = null,
+    endCondition = null,
+    bottomDeckRisk = null,
+  } = input;
   const result = await pool.query(
     `
     INSERT INTO event_session_round_team_results (
@@ -1648,18 +1777,31 @@ export async function submitRoundScore(input: {
       score,
       submitted_by_user_id,
       submitted_at,
-      replay_game_id
+      replay_game_id,
+      end_condition,
+      bottom_deck_risk
     )
-    VALUES ($1, $2, $3, $4, NOW(), $5)
+    VALUES ($1, $2, $3, $4, NOW(), $5, $6, $7)
     ON CONFLICT (round_id, team_no)
     DO UPDATE SET
       score = EXCLUDED.score,
       submitted_by_user_id = EXCLUDED.submitted_by_user_id,
       submitted_at = NOW(),
-      replay_game_id = EXCLUDED.replay_game_id
-    RETURNING id, round_id, team_no, score, submitted_by_user_id, submitted_at, replay_game_id::text
+      replay_game_id = EXCLUDED.replay_game_id,
+      end_condition = EXCLUDED.end_condition,
+      bottom_deck_risk = EXCLUDED.bottom_deck_risk
+    RETURNING
+      id,
+      round_id,
+      team_no,
+      score,
+      submitted_by_user_id,
+      submitted_at,
+      replay_game_id::text,
+      end_condition,
+      bottom_deck_risk::float8 AS bottom_deck_risk
     `,
-    [roundId, teamNo, score, submittedByUserId, replayGameId],
+    [roundId, teamNo, score, submittedByUserId, replayGameId, endCondition, bottomDeckRisk],
   );
 
   await pool.query(
@@ -1770,9 +1912,17 @@ export async function finalizeRoundElo(roundId: number): Promise<{
   round_id: number;
   team_count: number;
   ledger_rows: number;
+  team_meta: Array<{
+    team_no: number;
+    k_used: number;
+    victory_type: VictoryType;
+    end_condition: number | null;
+    bottom_deck_risk: number | null;
+  }>;
 }> {
   const client = await pool.connect();
   try {
+    await ensureRoundResultMetadataColumns();
     await client.query('BEGIN');
 
     const metaRes = await client.query<{
@@ -1793,6 +1943,7 @@ export async function finalizeRoundElo(roundId: number): Promise<{
       JOIN event_sessions s ON s.id = r.session_id
       LEFT JOIN event_session_ladder_config c ON c.event_id = s.event_id
       WHERE r.id = $1
+      FOR UPDATE OF r
       `,
       [roundId],
     );
@@ -1801,7 +1952,7 @@ export async function finalizeRoundElo(roundId: number): Promise<{
     }
     const meta = metaRes.rows[0];
     const eventId = meta.event_id;
-    const k = Number(meta.k_factor ?? 24);
+    const defaultK = Number(meta.k_factor ?? 24);
     const bonus = Number(meta.participation_bonus ?? 0.5);
 
     const existingLedgerRes = await client.query<{ count: string }>(
@@ -1814,6 +1965,34 @@ export async function finalizeRoundElo(roundId: number): Promise<{
     );
     const existingLedgerCount = Number(existingLedgerRes.rows[0]?.count ?? 0);
     if (existingLedgerCount > 0) {
+      const existingTeamMetaRes = await client.query<{
+        team_no: number;
+        end_condition: number | null;
+        bottom_deck_risk: number | null;
+      }>(
+        `
+        SELECT team_no, end_condition, bottom_deck_risk::float8 AS bottom_deck_risk
+        FROM event_session_round_team_results
+        WHERE round_id = $1
+        ORDER BY team_no
+        `,
+        [roundId],
+      );
+      const existingTeamMeta = existingTeamMetaRes.rows.map((row) => ({
+        team_no: row.team_no,
+        k_used: resolveRoundPairwiseKFactor({
+          teamCount: existingTeamMetaRes.rows.length,
+          defaultK,
+          endCondition: row.end_condition ?? null,
+          bottomDeckRisk: row.bottom_deck_risk ?? null,
+        }),
+        victory_type: classifyVictoryType({
+          endCondition: row.end_condition ?? null,
+          bottomDeckRisk: row.bottom_deck_risk ?? null,
+        }),
+        end_condition: row.end_condition ?? null,
+        bottom_deck_risk: row.bottom_deck_risk ?? null,
+      }));
       const existingTeamsRes = await client.query<{ count: string }>(
         `
         SELECT COUNT(*)::int AS count
@@ -1828,15 +2007,22 @@ export async function finalizeRoundElo(roundId: number): Promise<{
         round_id: roundId,
         team_count: Number(existingTeamsRes.rows[0]?.count ?? 0),
         ledger_rows: existingLedgerCount,
+        team_meta: existingTeamMeta,
       };
     }
 
     const teamsRes = await client.query<{
       team_no: number;
       score: number;
+      end_condition: number | null;
+      bottom_deck_risk: number | null;
     }>(
       `
-      SELECT team_no, score
+      SELECT
+        team_no,
+        score,
+        end_condition,
+        bottom_deck_risk::float8 AS bottom_deck_risk
       FROM event_session_round_team_results
       WHERE round_id = $1
       ORDER BY team_no
@@ -1905,20 +2091,21 @@ export async function finalizeRoundElo(roundId: number): Promise<{
           : 1000;
       return { ...t, players, avg_rating: avg };
     });
-
-    const teamDelta = new Map<number, number>();
-    for (const a of teamRows) {
-      let sum = 0;
-      let pairs = 0;
-      for (const b of teamRows) {
-        if (a.team_no === b.team_no) continue;
-        const expected = 1 / (1 + 10 ** ((b.avg_rating - a.avg_rating) / 400));
-        const actual = a.score > b.score ? 1 : a.score < b.score ? 0 : 0.5;
-        sum += actual - expected;
-        pairs += 1;
-      }
-      teamDelta.set(a.team_no, pairs > 0 ? (k * sum) / pairs : 0);
-    }
+    const teamDeltaRows = computeTeamCompetitiveDeltas({ teams: teamRows, defaultK });
+    const teamDelta = new Map<number, number>(teamDeltaRows.map((row) => [row.team_no, row.delta]));
+    const teamMeta = teamRows
+      .map((team) => {
+        const deltaRow = teamDeltaRows.find((row) => row.team_no === team.team_no);
+        if (!deltaRow) return null;
+        return {
+          team_no: team.team_no,
+          k_used: deltaRow.k_used,
+          victory_type: deltaRow.victory_type,
+          end_condition: team.end_condition ?? null,
+          bottom_deck_risk: team.bottom_deck_risk ?? null,
+        };
+      })
+      .filter((row): row is NonNullable<typeof row> => row != null);
 
     let ledgerRows = 0;
     for (const team of teamRows) {
@@ -1971,6 +2158,7 @@ export async function finalizeRoundElo(roundId: number): Promise<{
       round_id: roundId,
       team_count: teamRows.length,
       ledger_rows: ledgerRows,
+      team_meta: teamMeta,
     };
   } catch (err) {
     await client.query('ROLLBACK');

--- a/apps/api/tests/integration/session-ladder.scoring.test.ts
+++ b/apps/api/tests/integration/session-ladder.scoring.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { pool } from '../../src/config/db';
+import {
+  finalizeRoundElo,
+  submitRoundScore,
+} from '../../src/modules/session-ladder/session-ladder.service';
+
+type RoundSeed = {
+  roundId: number;
+  eventId: number;
+};
+
+async function seedRoundForFinalize(input: {
+  teamOneScore: number;
+  teamTwoScore: number;
+  teamOneEndCondition?: number | null;
+  teamTwoEndCondition?: number | null;
+  teamOneBdr?: number | null;
+  teamTwoBdr?: number | null;
+}): Promise<RoundSeed> {
+  const {
+    teamOneScore,
+    teamTwoScore,
+    teamOneEndCondition = 1,
+    teamTwoEndCondition = 1,
+    teamOneBdr = null,
+    teamTwoBdr = null,
+  } = input;
+
+  const eventRes = await pool.query<{ id: number }>(
+    `
+    INSERT INTO events (name, slug, short_description, long_description, event_format)
+    VALUES ('League Scoring Test', md5(random()::text), 'short', 'long', 'session_ladder')
+    RETURNING id
+    `,
+  );
+  const eventId = eventRes.rows[0].id;
+
+  await pool.query(
+    `
+    INSERT INTO event_session_ladder_config (event_id, k_factor, participation_bonus)
+    VALUES ($1, 24, 0)
+    `,
+    [eventId],
+  );
+
+  const sessionRes = await pool.query<{ id: number }>(
+    `
+    INSERT INTO event_sessions (event_id, session_index, status)
+    VALUES ($1, 1, 'live')
+    RETURNING id
+    `,
+    [eventId],
+  );
+  const sessionId = sessionRes.rows[0].id;
+
+  const roundRes = await pool.query<{ id: number }>(
+    `
+    INSERT INTO event_session_rounds (session_id, round_index, status, seed_payload)
+    VALUES ($1, 1, 'scoring', '{"variant":"No Variant","seed":"abc123"}')
+    RETURNING id
+    `,
+    [sessionId],
+  );
+  const roundId = roundRes.rows[0].id;
+
+  const usersRes = await pool.query<{ id: number }>(
+    `
+    INSERT INTO users (display_name, password_hash, role)
+    VALUES
+      (md5(random()::text), 'x', 'USER'),
+      (md5(random()::text), 'x', 'USER'),
+      (md5(random()::text), 'x', 'USER'),
+      (md5(random()::text), 'x', 'USER')
+    RETURNING id
+    `,
+  );
+  const [u1, u2, u3, u4] = usersRes.rows.map((row) => row.id);
+
+  await pool.query(
+    `
+    INSERT INTO event_session_round_players (round_id, user_id, role, assigned_team_no)
+    VALUES
+      ($1, $2, 'playing', 1),
+      ($1, $3, 'playing', 1),
+      ($1, $4, 'playing', 2),
+      ($1, $5, 'playing', 2)
+    `,
+    [roundId, u1, u2, u3, u4],
+  );
+
+  await submitRoundScore({
+    roundId,
+    teamNo: 1,
+    score: teamOneScore,
+    submittedByUserId: u1,
+    endCondition: teamOneEndCondition,
+    bottomDeckRisk: teamOneBdr,
+  });
+  await submitRoundScore({
+    roundId,
+    teamNo: 2,
+    score: teamTwoScore,
+    submittedByUserId: u3,
+    endCondition: teamTwoEndCondition,
+    bottomDeckRisk: teamTwoBdr,
+  });
+
+  return { roundId, eventId };
+}
+
+describe('session-ladder scoring finalize (integration)', () => {
+  beforeEach(async () => {
+    await pool.query(
+      `
+      TRUNCATE
+        event_rating_ledger,
+        event_player_ratings,
+        event_session_round_team_results,
+        event_session_round_players,
+        event_session_rounds,
+        event_sessions,
+        event_session_ladder_config,
+        team_memberships,
+        event_teams,
+        event_stages,
+        event_game_templates,
+        events,
+        users
+      RESTART IDENTITY CASCADE
+      `,
+    );
+  });
+
+  it('returns team metadata with k/victory_type and is idempotent', async () => {
+    const { roundId } = await seedRoundForFinalize({
+      teamOneScore: 25,
+      teamTwoScore: 20,
+      teamOneEndCondition: 3,
+      teamTwoEndCondition: 1,
+    });
+
+    const first = await finalizeRoundElo(roundId);
+    expect(first.ledger_rows).toBe(4);
+    expect(first.team_meta).toHaveLength(2);
+    expect(first.team_meta.map((row) => row.team_no).sort((a, b) => a - b)).toEqual([1, 2]);
+    expect(first.team_meta.find((row) => row.team_no === 1)?.victory_type).toBe('turns');
+
+    const countAfterFirst = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM event_rating_ledger WHERE round_id = $1`,
+      [roundId],
+    );
+    expect(Number(countAfterFirst.rows[0].count)).toBe(4);
+
+    const second = await finalizeRoundElo(roundId);
+    const countAfterSecond = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM event_rating_ledger WHERE round_id = $1`,
+      [roundId],
+    );
+    expect(second.ledger_rows).toBe(4);
+    expect(Number(countAfterSecond.rows[0].count)).toBe(4);
+  });
+
+  it('serializes concurrent finalize attempts for the same round', async () => {
+    const { roundId } = await seedRoundForFinalize({
+      teamOneScore: 21,
+      teamTwoScore: 20,
+      teamOneEndCondition: 1,
+      teamTwoEndCondition: 1,
+    });
+
+    const [a, b] = await Promise.all([finalizeRoundElo(roundId), finalizeRoundElo(roundId)]);
+    expect(a.ledger_rows).toBe(4);
+    expect(b.ledger_rows).toBe(4);
+
+    const ledgerCount = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM event_rating_ledger WHERE round_id = $1`,
+      [roundId],
+    );
+    expect(Number(ledgerCount.rows[0].count)).toBe(4);
+  });
+});

--- a/apps/api/tests/unit/replay/replay-parse.test.ts
+++ b/apps/api/tests/unit/replay/replay-parse.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractReplayExportPlayers,
+  extractReplayHistoryGames,
+  normalizeReplayEndCondition,
+} from '../../../src/modules/replay/replay-parse';
+
+describe('replay-parse helpers', () => {
+  it('extractReplayExportPlayers supports canonical and legacy keys', () => {
+    expect(extractReplayExportPlayers({ players: ['a', 'b'] })).toEqual(['a', 'b']);
+    expect(extractReplayExportPlayers({ playerNames: ['a', 'b'] })).toEqual(['a', 'b']);
+    expect(extractReplayExportPlayers({ player_names: ['a', 'b'] })).toEqual(['a', 'b']);
+  });
+
+  it('extractReplayExportPlayers rejects malformed values', () => {
+    expect(extractReplayExportPlayers({ players: ['a', 1] })).toBeNull();
+    expect(extractReplayExportPlayers({ players: [] })).toEqual([]);
+    expect(extractReplayExportPlayers({})).toBeNull();
+    expect(extractReplayExportPlayers(null)).toBeNull();
+  });
+
+  it('extractReplayHistoryGames supports array, games, and rows wrappers', () => {
+    const game = { id: 1 };
+    expect(extractReplayHistoryGames([game])).toEqual([game]);
+    expect(extractReplayHistoryGames({ games: [game] })).toEqual([game]);
+    expect(extractReplayHistoryGames({ rows: [game] })).toEqual([game]);
+    expect(extractReplayHistoryGames({})).toEqual([]);
+    expect(extractReplayHistoryGames(null)).toEqual([]);
+  });
+
+  it('normalizeReplayEndCondition normalizes or returns null', () => {
+    expect(normalizeReplayEndCondition(4)).toBe(4);
+    expect(normalizeReplayEndCondition('10')).toBe(10);
+    expect(normalizeReplayEndCondition(null)).toBeNull();
+    expect(normalizeReplayEndCondition(undefined)).toBeNull();
+    expect(normalizeReplayEndCondition('nope')).toBeNull();
+  });
+});
+

--- a/apps/api/tests/unit/replay/replay-parse.test.ts
+++ b/apps/api/tests/unit/replay/replay-parse.test.ts
@@ -36,4 +36,3 @@ describe('replay-parse helpers', () => {
     expect(normalizeReplayEndCondition('nope')).toBeNull();
   });
 });
-

--- a/apps/api/tests/unit/session-ladder/elo-logic.test.ts
+++ b/apps/api/tests/unit/session-ladder/elo-logic.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyVictoryType,
+  computeTeamCompetitiveDeltas,
+  resolveRoundPairwiseKFactor,
+} from '../../../src/modules/session-ladder/session-ladder.service';
+
+describe('session-ladder Elo logic', () => {
+  it('maps known outcomes to expected victory type', () => {
+    expect(classifyVictoryType({ endCondition: 3, bottomDeckRisk: null })).toBe('turns');
+    expect(classifyVictoryType({ endCondition: 4, bottomDeckRisk: null })).toBe('turns');
+    expect(classifyVictoryType({ endCondition: 10, bottomDeckRisk: null })).toBe('turns');
+    expect(classifyVictoryType({ endCondition: 1, bottomDeckRisk: null })).toBe('score');
+    expect(classifyVictoryType({ endCondition: 999, bottomDeckRisk: null })).toBe('score');
+    expect(classifyVictoryType({ endCondition: 3, bottomDeckRisk: 0 })).toBe('bottom_deck_risk');
+  });
+
+  it('resolves K matrix by team count bucket and mode', () => {
+    expect(
+      resolveRoundPairwiseKFactor({
+        teamCount: 2,
+        defaultK: 24,
+        endCondition: 1,
+        bottomDeckRisk: null,
+      }),
+    ).toBe(48);
+    expect(
+      resolveRoundPairwiseKFactor({
+        teamCount: 3,
+        defaultK: 24,
+        endCondition: 4,
+        bottomDeckRisk: null,
+      }),
+    ).toBe(10);
+    expect(
+      resolveRoundPairwiseKFactor({
+        teamCount: 4,
+        defaultK: 24,
+        endCondition: 1,
+        bottomDeckRisk: 2,
+      }),
+    ).toBe(16);
+    expect(
+      resolveRoundPairwiseKFactor({
+        teamCount: 1,
+        defaultK: 24,
+        endCondition: 1,
+        bottomDeckRisk: null,
+      }),
+    ).toBe(24);
+  });
+
+  it('computes expected deltas for two-team equal-rating win/loss', () => {
+    const deltas = computeTeamCompetitiveDeltas({
+      teams: [
+        { team_no: 1, score: 25, avg_rating: 1000, end_condition: 1, bottom_deck_risk: null },
+        { team_no: 2, score: 24, avg_rating: 1000, end_condition: 1, bottom_deck_risk: null },
+      ],
+      defaultK: 24,
+    });
+    const a = deltas.find((d) => d.team_no === 1);
+    const b = deltas.find((d) => d.team_no === 2);
+    expect(a?.delta).toBeCloseTo(24, 6);
+    expect(b?.delta).toBeCloseTo(-24, 6);
+    expect(a?.k_used).toBe(48);
+    expect(b?.k_used).toBe(48);
+  });
+
+  it('computes expected deltas for three-team rank ordering', () => {
+    const deltas = computeTeamCompetitiveDeltas({
+      teams: [
+        { team_no: 1, score: 25, avg_rating: 1000, end_condition: 1, bottom_deck_risk: null },
+        { team_no: 2, score: 20, avg_rating: 1000, end_condition: 1, bottom_deck_risk: null },
+        { team_no: 3, score: 10, avg_rating: 1000, end_condition: 1, bottom_deck_risk: null },
+      ],
+      defaultK: 24,
+    });
+    expect(deltas.find((d) => d.team_no === 1)?.delta).toBeCloseTo(30, 6);
+    expect(deltas.find((d) => d.team_no === 2)?.delta).toBeCloseTo(0, 6);
+    expect(deltas.find((d) => d.team_no === 3)?.delta).toBeCloseTo(-30, 6);
+  });
+
+  it('yields zero deltas for full tie at equal ratings', () => {
+    const deltas = computeTeamCompetitiveDeltas({
+      teams: [
+        { team_no: 1, score: 18, avg_rating: 1000, end_condition: 1, bottom_deck_risk: null },
+        { team_no: 2, score: 18, avg_rating: 1000, end_condition: 1, bottom_deck_risk: null },
+        { team_no: 3, score: 18, avg_rating: 1000, end_condition: 1, bottom_deck_risk: null },
+        { team_no: 4, score: 18, avg_rating: 1000, end_condition: 1, bottom_deck_risk: null },
+      ],
+      defaultK: 24,
+    });
+    deltas.forEach((row) => expect(row.delta).toBeCloseTo(0, 6));
+  });
+});
+

--- a/apps/api/tests/unit/session-ladder/elo-logic.test.ts
+++ b/apps/api/tests/unit/session-ladder/elo-logic.test.ts
@@ -93,4 +93,3 @@ describe('session-ladder Elo logic', () => {
     deltas.forEach((row) => expect(row.delta).toBeCloseTo(0, 6));
   });
 });
-

--- a/apps/api/tests/unit/session-ladder/end-condition-map.test.ts
+++ b/apps/api/tests/unit/session-ladder/end-condition-map.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  END_CONDITIONS_TURNS_VICTORY,
+  END_CONDITION_NAMES,
+} from '../../../src/modules/session-ladder/session-ladder.end-condition';
+import { classifyVictoryType } from '../../../src/modules/session-ladder/session-ladder.service';
+
+describe('session-ladder end-condition mapping', () => {
+  it('contains canonical labels and turns mapping', () => {
+    expect(END_CONDITION_NAMES[1]).toBe('Perfect');
+    expect(END_CONDITION_NAMES[2]).toBe('Strike Out');
+    expect(END_CONDITION_NAMES[3]).toBe('Time Out');
+    expect(END_CONDITION_NAMES[10]).toBe('Terminated By Vote');
+    expect(END_CONDITIONS_TURNS_VICTORY.has(3)).toBe(true);
+    expect(END_CONDITIONS_TURNS_VICTORY.has(4)).toBe(true);
+    expect(END_CONDITIONS_TURNS_VICTORY.has(10)).toBe(true);
+  });
+
+  it('treats unknown end conditions as score mode', () => {
+    expect(classifyVictoryType({ endCondition: 999, bottomDeckRisk: null })).toBe('score');
+  });
+});
+

--- a/apps/api/tests/unit/session-ladder/end-condition-map.test.ts
+++ b/apps/api/tests/unit/session-ladder/end-condition-map.test.ts
@@ -20,4 +20,3 @@ describe('session-ladder end-condition mapping', () => {
     expect(classifyVictoryType({ endCondition: 999, bottomDeckRisk: null })).toBe('score');
   });
 });
-

--- a/apps/web/src/design-system/styles/tokens.css
+++ b/apps/web/src/design-system/styles/tokens.css
@@ -169,12 +169,12 @@
   --ds-textScale-10-lineHeight: 1.2;
   --ds-textScale-11-fontSize: 40px;
   --ds-textScale-11-lineHeight: 1.2;
-  --ds-typography-fontFamily-display: 'Inter', sans-serif;
-  --ds-typography-fontFamily-heading: 'Inter', sans-serif;
-  --ds-typography-fontFamily-body: 'Inter', sans-serif;
-  --ds-typography-fontFamily-prose: 'Lora', serif;
-  --ds-typography-fontFamily-mono: 'Roboto Mono', monospace;
-  --ds-typography-fontFamily-meta: 'Inter', sans-serif;
+  --ds-typography-fontFamily-display: "Inter", sans-serif;
+  --ds-typography-fontFamily-heading: "Inter", sans-serif;
+  --ds-typography-fontFamily-body: "Inter", sans-serif;
+  --ds-typography-fontFamily-prose: "Lora", serif;
+  --ds-typography-fontFamily-mono: "Roboto Mono", monospace;
+  --ds-typography-fontFamily-meta: "Inter", sans-serif;
   --ds-typography-fontWeight-display: 800;
   --ds-typography-fontWeight-heading: 700;
   --ds-typography-fontWeight-body: 500;

--- a/apps/web/src/pages/SessionTeamPage.tsx
+++ b/apps/web/src/pages/SessionTeamPage.tsx
@@ -78,6 +78,7 @@ export function SessionTeamPage() {
   const [validateStatus, setValidateStatus] = useState<'idle' | 'loading' | 'ok' | 'error'>('idle');
   const [validateMessage, setValidateMessage] = useState<string | null>(null);
   const [derivedScore, setDerivedScore] = useState<number | null>(null);
+  const [derivedEndConditionCode, setDerivedEndConditionCode] = useState<number | null>(null);
   const [derivedEndCondition, setDerivedEndCondition] = useState<string | null>(null);
   const [bdrInput, setBdrInput] = useState('');
   const [savingScore, setSavingScore] = useState(false);
@@ -182,6 +183,7 @@ export function SessionTeamPage() {
     setValidateStatus('idle');
     setValidateMessage(null);
     setDerivedScore(null);
+    setDerivedEndConditionCode(null);
     setDerivedEndCondition(null);
     setBdrInput('');
   }, [rid, team]);
@@ -213,6 +215,7 @@ export function SessionTeamPage() {
       setValidateStatus('idle');
       setValidateMessage(null);
       setDerivedScore(null);
+      setDerivedEndConditionCode(null);
       setDerivedEndCondition(null);
       return;
     }
@@ -221,6 +224,7 @@ export function SessionTeamPage() {
       setValidateStatus('error');
       setValidateMessage('Unable to parse game ID from replay link.');
       setDerivedScore(null);
+      setDerivedEndConditionCode(null);
       setDerivedEndCondition(null);
       return;
     }
@@ -231,6 +235,7 @@ export function SessionTeamPage() {
     setValidateStatus('loading');
     setValidateMessage(null);
     setDerivedScore(null);
+    setDerivedEndConditionCode(null);
     setDerivedEndCondition(null);
     try {
       const resp = await postJsonAuth<{
@@ -257,6 +262,7 @@ export function SessionTeamPage() {
       setValidateStatus('ok');
       setValidateMessage('Replay validated.');
       setDerivedScore(resp.derived.score);
+      setDerivedEndConditionCode(resp.derived.endCondition ?? null);
       setDerivedEndCondition(mapEndCondition(resp.derived.endCondition));
     } catch (err) {
       const msg =
@@ -266,6 +272,7 @@ export function SessionTeamPage() {
       setValidateStatus('error');
       setValidateMessage(msg);
       setDerivedScore(null);
+      setDerivedEndConditionCode(null);
       setDerivedEndCondition(null);
     }
   }
@@ -281,6 +288,11 @@ export function SessionTeamPage() {
       setError('Missing score from replay validation.');
       return;
     }
+    const normalizedBdr = bdrInput.trim() ? Number(bdrInput) : null;
+    if (normalizedBdr != null && !Number.isFinite(normalizedBdr)) {
+      setError('BDR must be a valid number when provided.');
+      return;
+    }
     setSavingScore(true);
     setError(null);
     try {
@@ -288,6 +300,8 @@ export function SessionTeamPage() {
         team_no: team,
         score: derivedScore,
         replay_game_id: replayGameId ? Number(replayGameId) : null,
+        end_condition: derivedEndConditionCode,
+        bottom_deck_risk: normalizedBdr,
       });
       if (slug) navigate(`/events/${slug}`, { replace: true });
     } catch (err) {


### PR DESCRIPTION
## Summary
- harden replay parsing for export/history payload variants and normalize end-condition values
- enforce exact team composition for leagues and exact/pool modes for challenges
- strengthen league Elo finalize logic with explicit end-condition mapping, reusable Elo primitives, and round-level locking for concurrency/idempotency
- include team-level finalize trace metadata (`k_used`, `victory_type`, `end_condition`, `bottom_deck_risk`)
- wire team room submit payload to include replay-derived end condition and user-entered BDR

## Testing
- `pnpm -C apps/api run typecheck`
- `pnpm -C apps/api exec eslint src/modules/events/event.routes.ts src/modules/session-ladder/session-ladder.routes.ts src/modules/session-ladder/session-ladder.service.ts src/modules/replay/replay-parse.ts tests/unit/replay/replay-parse.test.ts tests/unit/session-ladder/elo-logic.test.ts tests/unit/session-ladder/end-condition-map.test.ts tests/integration/session-ladder.scoring.test.ts`
- `pnpm -C apps/api exec vitest run tests/unit/replay/replay-parse.test.ts tests/unit/session-ladder/elo-logic.test.ts tests/unit/session-ladder/end-condition-map.test.ts`
- `pnpm -C apps/api exec vitest run tests/integration/session-ladder.scoring.test.ts -c vitest.integration.config.mts`

## Notes
- left unrelated local edit in `apps/web/src/design-system/styles/tokens.css` out of this PR.
