### PR TITLE
feat(infra): manage Render FE/BE domains via blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,27 @@
+services:
+  - type: web
+    name: hanabi-challenges
+    runtime: static
+    buildCommand: pnpm install --frozen-lockfile && pnpm -C apps/web run build
+    staticPublishPath: ./apps/web/dist
+    domains:
+      - www.hanabi-challenges.com
+    routes:
+      - type: rewrite
+        source: /api/*
+        destination: https://api.hanabi-challenges.com/api/*
+      - type: rewrite
+        source: /ws/*
+        destination: wss://api.hanabi-challenges.com/ws/*
+      - type: rewrite
+        source: /*
+        destination: /index.html
+
+  - type: web
+    name: hanabi-challenges-api-prod
+    runtime: node
+    buildCommand: pnpm install --frozen-lockfile && pnpm -C apps/api run build
+    startCommand: pnpm -C apps/api run start
+    healthCheckPath: /health
+    domains:
+      - api.hanabi-challenges.com


### PR DESCRIPTION
## Summary
- add root `render.yaml` blueprint for Render-managed infrastructure
- define static FE service with `www.hanabi-challenges.com` domain and route rewrites for `/api/*`, `/ws/*`, and SPA fallback
- define Node BE service with `api.hanabi-challenges.com` custom domain and `/health` health check

## Why
- moves domain/rewrite config into version control
- avoids UI-only drift and gives repeatable infra setup

## Validation
- `pnpm run ci:tests` passes locally on the scoring branch before creating this infra PR
