### PR TITLE
fix(ci): restore PR trigger for ci-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+  pull_request:
+    branches: ['main']
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Restores the CI workflow triggers so required check `ci-tests` can be reported on PRs again.

Changes:
- `push` trigger uses canonical form (`push:`)
- `pull_request` trigger is restored for `main`
- keeps `workflow_dispatch`
