### PR TITLE
chore(render): codify full FE/BE/DB blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
-    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/web run build
+    buildCommand: npm install -g pnpm@10.30.3 && pnpm install --frozen-lockfile && pnpm -C apps/web run build
     staticPublishPath: ./apps/web/dist
     domains:
       - hanabi-challenges.com
@@ -37,7 +37,7 @@ services:
           property: connectionString
       - key: JWT_SECRET
         sync: false
-    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/api run build
+    buildCommand: npm install -g pnpm@10.30.3 && pnpm install --frozen-lockfile && pnpm -C apps/api run build
     startCommand: pnpm -C apps/api run start
     healthCheckPath: /health
     domains:

--- a/render.yaml
+++ b/render.yaml
@@ -2,9 +2,14 @@ services:
   - type: web
     name: hanabi-challenges
     runtime: static
+    plan: starter
+    envVars:
+      - key: NODE_VERSION
+        value: 22.12.0
     buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/web run build
     staticPublishPath: ./apps/web/dist
     domains:
+      - hanabi-challenges.com
       - www.hanabi-challenges.com
     routes:
       - type: rewrite
@@ -20,8 +25,26 @@ services:
   - type: web
     name: hanabi-challenges-api-prod
     runtime: node
+    plan: starter
+    envVars:
+      - key: NODE_VERSION
+        value: 22.12.0
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        fromDatabase:
+          name: hanabi-challenges-db
+          property: connectionString
+      - key: JWT_SECRET
+        sync: false
     buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/api run build
     startCommand: pnpm -C apps/api run start
     healthCheckPath: /health
     domains:
       - api.hanabi-challenges.com
+
+databases:
+  - name: hanabi-challenges-db
+    plan: starter
+    databaseName: hanabi
+    user: hanabi


### PR DESCRIPTION
## Summary
- codify FE, BE, and DB resources in `render.yaml`
- add env wiring for API (`DATABASE_URL` from DB, `JWT_SECRET` as manual secret)
- include apex + www frontend domains and API domain
- pin `NODE_VERSION=22.12.0` for services
- fix Render build failures by bypassing Corepack key verification and installing pnpm directly

## Key fix
Render was failing at `corepack prepare pnpm@10.30.3` with key-id verification errors.
Build now uses:
`npm install -g pnpm@10.30.3 && pnpm ...`

## Notes
- `JWT_SECRET` remains manual (`sync: false`) and must be set in Render.
- Existing services should be mapped during Blueprint sync to avoid duplicates.
