### PR TITLE
fix(render): complete blueprint with supported plans

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
-    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/web run build
+    buildCommand: npm install -g pnpm@10.30.3 && pnpm install --frozen-lockfile && pnpm -C apps/web run build
     staticPublishPath: ./apps/web/dist
     domains:
       - hanabi-challenges.com
@@ -37,7 +37,7 @@ services:
           property: connectionString
       - key: JWT_SECRET
         sync: false
-    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/api run build
+    buildCommand: npm install -g pnpm@10.30.3 && pnpm install --frozen-lockfile && pnpm -C apps/api run build
     startCommand: pnpm -C apps/api run start
     healthCheckPath: /health
     domains:

--- a/render.yaml
+++ b/render.yaml
@@ -2,9 +2,14 @@ services:
   - type: web
     name: hanabi-challenges
     runtime: static
+    plan: starter
+    envVars:
+      - key: NODE_VERSION
+        value: 22.12.0
     buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/web run build
     staticPublishPath: ./apps/web/dist
     domains:
+      - hanabi-challenges.com
       - www.hanabi-challenges.com
     routes:
       - type: rewrite
@@ -20,8 +25,26 @@ services:
   - type: web
     name: hanabi-challenges-api-prod
     runtime: node
+    plan: starter
+    envVars:
+      - key: NODE_VERSION
+        value: 22.12.0
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        fromDatabase:
+          name: hanabi-challenges-db
+          property: connectionString
+      - key: JWT_SECRET
+        sync: false
     buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/api run build
     startCommand: pnpm -C apps/api run start
     healthCheckPath: /health
     domains:
       - api.hanabi-challenges.com
+
+databases:
+  - name: hanabi-challenges-db
+    plan: starter
+    databaseName: hanabi
+    user: hanabi

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,6 @@ services:
   - type: web
     name: hanabi-challenges
     runtime: static
-    plan: starter
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
@@ -25,7 +24,6 @@ services:
   - type: web
     name: hanabi-challenges-api-prod
     runtime: node
-    plan: starter
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
@@ -45,6 +43,6 @@ services:
 
 databases:
   - name: hanabi-challenges-db
-    plan: starter
+    plan: basic-256mb
     databaseName: hanabi
     user: hanabi


### PR DESCRIPTION
## Summary
- codify FE/BE/DB in `render.yaml`
- use supported plan configuration for current Render Blueprint validation
- keep Corepack bypass (`npm install -g pnpm@10.30.3`) to avoid key-id verification failures
- keep API env wiring (`DATABASE_URL` from DB, `JWT_SECRET` manual secret)

## Why
Previous PR was closed; this re-opens the Render blueprint updates with the latest fixes needed for successful sync/deploy.
