### PR TITLE
fix(render): avoid pnpm EEXIST by using npx pnpm

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
-    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/web run build
+    buildCommand: npm install -g pnpm@10.30.3 && pnpm install --frozen-lockfile && pnpm -C apps/web run build
     staticPublishPath: ./apps/web/dist
     domains:
       - hanabi-challenges.com
@@ -37,7 +37,7 @@ services:
           property: connectionString
       - key: JWT_SECRET
         sync: false
-    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/api run build
+    buildCommand: npm install -g pnpm@10.30.3 && pnpm install --frozen-lockfile && pnpm -C apps/api run build
     startCommand: pnpm -C apps/api run start
     healthCheckPath: /health
     domains:

--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
-    buildCommand: npm install -g pnpm@10.30.3 && pnpm install --frozen-lockfile && pnpm -C apps/web run build
+    buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/web run build
     staticPublishPath: ./apps/web/dist
     domains:
       - hanabi-challenges.com
@@ -35,7 +35,7 @@ services:
           property: connectionString
       - key: JWT_SECRET
         sync: false
-    buildCommand: npm install -g pnpm@10.30.3 && pnpm install --frozen-lockfile && pnpm -C apps/api run build
+    buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/api run build
     startCommand: pnpm -C apps/api run start
     healthCheckPath: /health
     domains:

--- a/render.yaml
+++ b/render.yaml
@@ -2,9 +2,14 @@ services:
   - type: web
     name: hanabi-challenges
     runtime: static
+    plan: starter
+    envVars:
+      - key: NODE_VERSION
+        value: 22.12.0
     buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/web run build
     staticPublishPath: ./apps/web/dist
     domains:
+      - hanabi-challenges.com
       - www.hanabi-challenges.com
     routes:
       - type: rewrite
@@ -20,8 +25,26 @@ services:
   - type: web
     name: hanabi-challenges-api-prod
     runtime: node
+    plan: starter
+    envVars:
+      - key: NODE_VERSION
+        value: 22.12.0
+      - key: NODE_ENV
+        value: production
+      - key: DATABASE_URL
+        fromDatabase:
+          name: hanabi-challenges-db
+          property: connectionString
+      - key: JWT_SECRET
+        sync: false
     buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile && pnpm -C apps/api run build
     startCommand: pnpm -C apps/api run start
     healthCheckPath: /health
     domains:
       - api.hanabi-challenges.com
+
+databases:
+  - name: hanabi-challenges-db
+    plan: starter
+    databaseName: hanabi
+    user: hanabi

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,6 @@ services:
   - type: web
     name: hanabi-challenges
     runtime: static
-    plan: starter
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
@@ -25,7 +24,6 @@ services:
   - type: web
     name: hanabi-challenges-api-prod
     runtime: node
-    plan: starter
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
@@ -45,6 +43,6 @@ services:
 
 databases:
   - name: hanabi-challenges-db
-    plan: starter
+    plan: basic-256mb
     databaseName: hanabi
     user: hanabi


### PR DESCRIPTION
Follow-up to #20.

Render build fails with:
- `npm ERR! EEXIST ... /bin/pnpm`

This switches build commands to use ephemeral pnpm via npx:
- `npx -y pnpm@10.30.3 install ...`
- `npx -y pnpm@10.30.3 -C apps/web run build`
- `npx -y pnpm@10.30.3 -C apps/api run build`

This avoids global binary collisions in Render's Node image.
