### PR TITLE
fix(render): avoid corepack at api startup

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only --prefer-ts-exts src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node dist/src/index.js",
     "test": "vitest run",
     "test:unit": "vitest run -c vitest.unit.config.mts",
     "test:integration": "vitest run -c vitest.integration.config.mts --maxWorkers=1",

--- a/render.yaml
+++ b/render.yaml
@@ -36,7 +36,7 @@ services:
       - key: JWT_SECRET
         sync: false
     buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/api run build
-    startCommand: pnpm -C apps/api run start
+    startCommand: node apps/api/dist/src/index.js
     healthCheckPath: /health
     domains:
       - api.hanabi-challenges.com


### PR DESCRIPTION
## Summary
- switch API Render start command to direct Node entrypoint (`node apps/api/dist/src/index.js`)
- align `apps/api` local start script with actual TypeScript build output path (`dist/src/index.js`)

## Why
Render build now succeeds with `npx pnpm`, but deploy/runtime still failed because startup invoked `pnpm` (Corepack key-id issue). This removes package-manager usage at runtime.

## Validation
- `npx -y pnpm@10.30.3 -C apps/api run build`
- verified `apps/api/dist/src/index.js` exists after build
