### PR TITLE
fix(render): bootstrap db schema and stabilize Postgres TLS

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only --prefer-ts-exts src/index.ts",
     "build": "tsc",
+    "db:bootstrap": "node dist/src/scripts/bootstrap-db.js",
     "start": "node dist/src/index.js",
     "test": "vitest run",
     "test:unit": "vitest run -c vitest.unit.config.mts",

--- a/apps/api/src/config/db.ts
+++ b/apps/api/src/config/db.ts
@@ -1,6 +1,5 @@
 import { Pool } from 'pg';
 import { env } from './env';
+import { buildPgClientConfig } from './pg';
 
-export const pool = new Pool({
-  connectionString: env.DATABASE_URL,
-});
+export const pool = new Pool(buildPgClientConfig(env.DATABASE_URL));

--- a/apps/api/src/config/pg.ts
+++ b/apps/api/src/config/pg.ts
@@ -1,0 +1,35 @@
+import type { ClientConfig } from 'pg';
+
+function shouldUseSslFromUrl(connectionString: string): boolean {
+  try {
+    const hostname = new URL(connectionString).hostname.toLowerCase();
+    // Render external Postgres hosts require TLS.
+    return hostname.includes('.render.com') || hostname.includes('.onrender.com');
+  } catch {
+    return false;
+  }
+}
+
+function shouldUseSslFromMode(modeRaw: string | undefined): boolean | null {
+  if (!modeRaw) return null;
+  const mode = modeRaw.trim().toLowerCase();
+  if (!mode) return null;
+  if (mode === 'disable') return false;
+  return true;
+}
+
+export function buildPgClientConfig(connectionString: string): Pick<ClientConfig, 'connectionString' | 'ssl'> {
+  const modeDecision = shouldUseSslFromMode(process.env.PGSSLMODE);
+  const useSsl = modeDecision ?? shouldUseSslFromUrl(connectionString);
+
+  if (!useSsl) {
+    return { connectionString };
+  }
+
+  return {
+    connectionString,
+    ssl: {
+      rejectUnauthorized: false,
+    },
+  };
+}

--- a/apps/api/src/config/pg.ts
+++ b/apps/api/src/config/pg.ts
@@ -18,7 +18,9 @@ function shouldUseSslFromMode(modeRaw: string | undefined): boolean | null {
   return true;
 }
 
-export function buildPgClientConfig(connectionString: string): Pick<ClientConfig, 'connectionString' | 'ssl'> {
+export function buildPgClientConfig(
+  connectionString: string,
+): Pick<ClientConfig, 'connectionString' | 'ssl'> {
   const modeDecision = shouldUseSslFromMode(process.env.PGSSLMODE);
   const useSsl = modeDecision ?? shouldUseSslFromUrl(connectionString);
 

--- a/apps/api/src/modules/notifications/notifications.ws.ts
+++ b/apps/api/src/modules/notifications/notifications.ws.ts
@@ -3,6 +3,7 @@ import { WebSocketServer, type WebSocket } from 'ws';
 import jwt from 'jsonwebtoken';
 import { Client } from 'pg';
 import { env } from '../../config/env';
+import { buildPgClientConfig } from '../../config/pg';
 
 type NotificationSocketMessage =
   | {
@@ -78,7 +79,7 @@ export async function startNotificationDbListener(): Promise<void> {
   if (listenerStarted) return;
   listenerStarted = true;
 
-  const client = new Client({ connectionString: env.DATABASE_URL });
+  const client = new Client(buildPgClientConfig(env.DATABASE_URL));
   await client.connect();
   await client.query('LISTEN user_notification');
 

--- a/apps/api/src/scripts/bootstrap-db.ts
+++ b/apps/api/src/scripts/bootstrap-db.ts
@@ -1,0 +1,44 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { Pool } from 'pg';
+import { buildPgClientConfig } from '../config/pg';
+
+function resolveSchemaPath(): string {
+  const fromRepoRoot = path.resolve(process.cwd(), 'apps/api/db/schema.sql');
+  const fromApiDir = path.resolve(process.cwd(), 'db/schema.sql');
+  return process.cwd().endsWith(path.join('apps', 'api')) ? fromApiDir : fromRepoRoot;
+}
+
+async function main(): Promise<void> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is not set');
+  }
+
+  const schemaPath = resolveSchemaPath();
+  const schemaSql = await fs.readFile(schemaPath, 'utf8');
+  const pool = new Pool(buildPgClientConfig(connectionString));
+
+  try {
+    const check = await pool.query<{ users_table: string | null }>(
+      "SELECT to_regclass('public.users') AS users_table",
+    );
+    const usersTable = check.rows[0]?.users_table ?? null;
+
+    if (usersTable) {
+      console.log('[db-bootstrap] Existing schema detected; skipping initialization.');
+      return;
+    }
+
+    console.log('[db-bootstrap] No users table found. Applying apps/api/db/schema.sql...');
+    await pool.query(schemaSql);
+    console.log('[db-bootstrap] Schema initialization complete.');
+  } finally {
+    await pool.end();
+  }
+}
+
+void main().catch((err) => {
+  console.error('[db-bootstrap] Failed:', err);
+  process.exit(1);
+});

--- a/render.yaml
+++ b/render.yaml
@@ -36,6 +36,7 @@ services:
       - key: JWT_SECRET
         sync: false
     buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/api run build
+    preDeployCommand: node apps/api/dist/src/scripts/bootstrap-db.js
     startCommand: node apps/api/dist/src/index.js
     healthCheckPath: /health
     domains:


### PR DESCRIPTION
## Summary
- add guarded DB bootstrap script that applies `apps/api/db/schema.sql` only when `public.users` does not exist
- wire API Render `preDeployCommand` to run bootstrap before starting app
- centralize Postgres connection config in `apps/api/src/config/pg.ts`
- apply shared PG config to both pool and notifications DB listener client

## Why
- Render deploys were failing after startup due to empty database (`relation users/events does not exist`)
- external Render Postgres URLs require TLS; DB config was inconsistent between pool/listener
- this keeps DB wiring in-repo and removes manual one-off setup steps

## Validation
- `npx -y pnpm@10.30.3 -C apps/api run build`
