### PR TITLE
fix(render): allow external database url override

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -3,11 +3,11 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const BACKEND_PORT = Number(process.env.PORT || process.env.BACKEND_PORT) || 4000;
-const DATABASE_URL = process.env.DATABASE_URL;
+const DATABASE_URL = process.env.DATABASE_URL_OVERRIDE || process.env.DATABASE_URL;
 const JWT_SECRET = process.env.JWT_SECRET;
 
 if (!DATABASE_URL) {
-  throw new Error('DATABASE_URL is not set');
+  throw new Error('DATABASE_URL is not set (or DATABASE_URL_OVERRIDE)');
 }
 
 if (!JWT_SECRET) {

--- a/apps/api/src/scripts/bootstrap-db.ts
+++ b/apps/api/src/scripts/bootstrap-db.ts
@@ -10,9 +10,9 @@ function resolveSchemaPath(): string {
 }
 
 async function main(): Promise<void> {
-  const connectionString = process.env.DATABASE_URL;
+  const connectionString = process.env.DATABASE_URL_OVERRIDE || process.env.DATABASE_URL;
   if (!connectionString) {
-    throw new Error('DATABASE_URL is not set');
+    throw new Error('DATABASE_URL is not set (or DATABASE_URL_OVERRIDE)');
   }
 
   const schemaPath = resolveSchemaPath();

--- a/render.yaml
+++ b/render.yaml
@@ -33,6 +33,8 @@ services:
         fromDatabase:
           name: hanabi-challenges-db
           property: connectionString
+      - key: DATABASE_URL_OVERRIDE
+        sync: false
       - key: JWT_SECRET
         sync: false
     buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/api run build


### PR DESCRIPTION
## Summary
- add runtime DB URL fallback: `DATABASE_URL_OVERRIDE` takes precedence over `DATABASE_URL`
- apply the same fallback in predeploy DB bootstrap script
- declare `DATABASE_URL_OVERRIDE` in `render.yaml` as a manual env var (`sync: false`)

## Why
`fromDatabase.connectionString` is Render private-network only. If private DNS fails in a given setup, deploys fail with `ENOTFOUND` before startup. This keeps blueprint wiring intact while allowing an explicit external URL override without fighting synced env vars.

## Validation
- `pnpm -C apps/api run format:check`
- `pnpm -C apps/api run build`
