### PR TITLE
chore(render): enforce internal database wiring only

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -3,11 +3,11 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const BACKEND_PORT = Number(process.env.PORT || process.env.BACKEND_PORT) || 4000;
-const DATABASE_URL = process.env.DATABASE_URL_OVERRIDE || process.env.DATABASE_URL;
+const DATABASE_URL = process.env.DATABASE_URL;
 const JWT_SECRET = process.env.JWT_SECRET;
 
 if (!DATABASE_URL) {
-  throw new Error('DATABASE_URL is not set (or DATABASE_URL_OVERRIDE)');
+  throw new Error('DATABASE_URL is not set');
 }
 
 if (!JWT_SECRET) {

--- a/apps/api/src/scripts/bootstrap-db.ts
+++ b/apps/api/src/scripts/bootstrap-db.ts
@@ -10,9 +10,9 @@ function resolveSchemaPath(): string {
 }
 
 async function main(): Promise<void> {
-  const connectionString = process.env.DATABASE_URL_OVERRIDE || process.env.DATABASE_URL;
+  const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
-    throw new Error('DATABASE_URL is not set (or DATABASE_URL_OVERRIDE)');
+    throw new Error('DATABASE_URL is not set');
   }
 
   const schemaPath = resolveSchemaPath();

--- a/render.yaml
+++ b/render.yaml
@@ -33,8 +33,6 @@ services:
         fromDatabase:
           name: hanabi-challenges-db
           property: connectionString
-      - key: DATABASE_URL_OVERRIDE
-        sync: false
       - key: JWT_SECRET
         sync: false
     buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/api run build


### PR DESCRIPTION
## Summary
- remove `DATABASE_URL_OVERRIDE` fallback from API runtime config
- remove `DATABASE_URL_OVERRIDE` fallback from predeploy bootstrap script
- remove `DATABASE_URL_OVERRIDE` env key from `render.yaml`

## Why
Use Render's prescribed private-network DB wiring only (`fromDatabase.connectionString`) and avoid mixed internal/external DB paths.

## Validation
- `pnpm -C apps/api run format:check`
- `pnpm -C apps/api run build`
