### PR TITLE
fix(render): run db bootstrap inside startCommand for private network access

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -3,11 +3,11 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const BACKEND_PORT = Number(process.env.PORT || process.env.BACKEND_PORT) || 4000;
-const DATABASE_URL = process.env.DATABASE_URL_OVERRIDE || process.env.DATABASE_URL;
+const DATABASE_URL = process.env.DATABASE_URL;
 const JWT_SECRET = process.env.JWT_SECRET;
 
 if (!DATABASE_URL) {
-  throw new Error('DATABASE_URL is not set (or DATABASE_URL_OVERRIDE)');
+  throw new Error('DATABASE_URL is not set');
 }
 
 if (!JWT_SECRET) {

--- a/apps/api/src/scripts/bootstrap-db.ts
+++ b/apps/api/src/scripts/bootstrap-db.ts
@@ -10,9 +10,9 @@ function resolveSchemaPath(): string {
 }
 
 async function main(): Promise<void> {
-  const connectionString = process.env.DATABASE_URL_OVERRIDE || process.env.DATABASE_URL;
+  const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
-    throw new Error('DATABASE_URL is not set (or DATABASE_URL_OVERRIDE)');
+    throw new Error('DATABASE_URL is not set');
   }
 
   const schemaPath = resolveSchemaPath();

--- a/render.yaml
+++ b/render.yaml
@@ -33,8 +33,6 @@ services:
         fromDatabase:
           name: hanabi-challenges-db
           property: connectionString
-      - key: DATABASE_URL_OVERRIDE
-        sync: false
       - key: JWT_SECRET
         sync: false
     buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/api run build

--- a/render.yaml
+++ b/render.yaml
@@ -36,8 +36,7 @@ services:
       - key: JWT_SECRET
         sync: false
     buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/api run build
-    preDeployCommand: node apps/api/dist/src/scripts/bootstrap-db.js
-    startCommand: node apps/api/dist/src/index.js
+    startCommand: node apps/api/dist/src/scripts/bootstrap-db.js && node apps/api/dist/src/index.js
     healthCheckPath: /health
     domains:
       - api.hanabi-challenges.com


### PR DESCRIPTION
## Summary

- Removes `preDeployCommand` from `render.yaml`
- Moves `bootstrap-db.js` to prefix the `startCommand` so it runs inside the live service instance
- Removes the `DATABASE_URL_OVERRIDE` escape hatch — `DATABASE_URL` (internal connection string) is now the only source

## Why

Pre-deploy commands run in a build-like container that cannot resolve Render's internal database hostnames (e.g. `dpg-xxxxx-a`), causing `getaddrinfo ENOTFOUND`. The `startCommand` runs inside the service instance on the private network, where the internal hostname is resolvable.

## Test plan

- [ ] Deploy to Render from this branch
- [ ] Confirm bootstrap log shows either "Applying schema" or "Existing schema detected; skipping"
- [ ] Confirm service passes health check at `/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)