### PR TITLE
fix(render): move db bootstrap to startCommand and add hostname logging

### DIFF
--- a/apps/api/src/scripts/bootstrap-db.ts
+++ b/apps/api/src/scripts/bootstrap-db.ts
@@ -15,6 +15,13 @@ async function main(): Promise<void> {
     throw new Error('DATABASE_URL is not set');
   }
 
+  try {
+    const { hostname } = new URL(connectionString);
+    console.log(`[db-bootstrap] Connecting to host: ${hostname}`);
+  } catch {
+    console.log('[db-bootstrap] DATABASE_URL is not a valid URL');
+  }
+
   const schemaPath = resolveSchemaPath();
   const schemaSql = await fs.readFile(schemaPath, 'utf8');
   const pool = new Pool(buildPgClientConfig(connectionString));


### PR DESCRIPTION
## Summary

- Removes `preDeployCommand` and moves `bootstrap-db.js` to prefix the `startCommand`, so it runs inside the service instance on Render's private network
- Removes the `DATABASE_URL_OVERRIDE` escape hatch — `DATABASE_URL` (internal connection string via `fromDatabase`) is the only source
- Adds hostname logging at bootstrap startup to make connection failures easier to diagnose

## Why

Pre-deploy commands run in a build container that cannot resolve Render internal database hostnames (`dpg-xxxxx-a`). The `startCommand` runs in the live service instance on the private network where internal hostnames are resolvable.

The hostname log line (`[db-bootstrap] Connecting to host: ...`) will confirm on each deploy whether `DATABASE_URL` is being correctly sourced from the `fromDatabase` reference or from a stale dashboard override.

## Test plan

- [ ] Deploy to Render from this branch
- [ ] Confirm log shows `[db-bootstrap] Connecting to host: dpg-...-a` (internal hostname)
- [ ] Confirm bootstrap completes ("Applying schema" or "Existing schema detected; skipping")
- [ ] Confirm service passes health check at `/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)