### PR TITLE
fix(render): pin services to virginia region for private network DNS

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -24,6 +24,7 @@ services:
   - type: web
     name: hanabi-challenges-api-prod
     runtime: node
+    region: virginia
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
@@ -44,5 +45,6 @@ services:
 databases:
   - name: hanabi-challenges-db
     plan: basic-256mb
+    region: virginia
     databaseName: hanabi
     user: hanabi


### PR DESCRIPTION
## Summary

- Adds `region: virginia` to both the `hanabi-challenges-api-prod` web service and the `hanabi-challenges-db` database in `render.yaml`

## Why

The database is in Virginia (US East). Without an explicit region, the web service was defaulting to a different region. Render's internal DNS (used for `dpg-xxxxx-a` hostnames) is region-scoped — cross-region private networking doesn't work, causing `getaddrinfo ENOTFOUND` on every deploy.

## Test plan

- [ ] Deploy to Render from this branch
- [ ] Confirm `[db-bootstrap] Connecting to host: dpg-...-a` resolves successfully
- [ ] Confirm bootstrap completes ("Applying schema" or "Existing schema detected; skipping")
- [ ] Confirm service passes health check at `/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)