### PR TITLE
feat: make homepage intro prose CMS-driven

### DIFF
--- a/apps/api/src/modules/site-content/site-content.service.ts
+++ b/apps/api/src/modules/site-content/site-content.service.ts
@@ -21,6 +21,13 @@ type SiteContentDefault = {
 
 const DEFAULT_SITE_CONTENT: SiteContentDefault[] = [
   {
+    slug: 'home',
+    title: 'Homepage',
+    markdown: `Welcome! This is where Hanabi players organize and track community challenges and tournaments. You can browse current events, see their rules and timelines, and join with your team to play through preset seeds.
+
+We keep your team's progress and results together so everyone knows where they stand. If you're curious about an event, click in to see the format and how to participate. If you're ready to play, register a team and start logging games.`,
+  },
+  {
     slug: 'about',
     title: 'About Hanabi Challenges',
     markdown: `# About Hanabi Challenges

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -5,7 +5,6 @@ import {
   Heading,
   Inline,
   PageContainer,
-  Prose,
   Section,
   Stack,
   Text,
@@ -13,9 +12,12 @@ import {
 } from '../design-system';
 import { EventCard } from '../features/events';
 import { useEvents } from '../hooks/useEvents';
+import { usePublicContentPage } from './ContentPage';
+import { MarkdownRenderer } from '../ui/MarkdownRenderer';
 
 export const LandingPage: React.FC = () => {
   const { events, loading, error } = useEvents();
+  const { page: homePage } = usePublicContentPage('home');
   const [now] = React.useState(() => Date.now());
   const activeEvents = useMemo(() => {
     return events.filter((e) => {
@@ -43,18 +45,11 @@ export const LandingPage: React.FC = () => {
     <Main>
       <PageContainer>
         <Section paddingY="lg" header={<Heading level={1}>Hanabi Competitions</Heading>}>
-          <Section>
-            <Prose>
-              Welcome! This is where Hanabi players organize and track community challenges and
-              tournaments. You can browse current events, see their rules and timelines, and join
-              with your team to play through preset seeds.
-            </Prose>
-            <Prose>
-              We keep your team’s progress and results together so everyone knows where they stand.
-              If you’re curious about an event, click in to see the format and how to participate.
-              If you’re ready to play, register a team and start logging games.
-            </Prose>
-          </Section>
+          {homePage && (
+            <Section>
+              <MarkdownRenderer markdown={homePage.markdown} />
+            </Section>
+          )}
 
           <Section header={<Heading level={2}>Ongoing Competitions</Heading>}>
             {loading && <Text variant="muted">Loading…</Text>}


### PR DESCRIPTION
## Summary
- Seeds a \`home\` slug in \`site_content_pages\` with the current landing page intro text
- \`LandingPage\` now fetches \`/content/pages/home\` via \`usePublicContentPage\` and renders the result with \`MarkdownRenderer\`
- Replaces the two hardcoded \`<Prose>\` paragraphs; the hardcoded text becomes the seed default, so existing behavior is preserved on first deploy
- Fail-silent: if the fetch fails or is still in-flight, the prose section is omitted — the events list and rest of the page are unaffected
- Admins can edit the copy live via the existing **Admin → Content → home** editor without a redeploy

## Test plan
- [ ] Landing page renders intro prose as before
- [ ] Editing the \`home\` page via `/admin/content/home` updates the landing page prose immediately on next load
- [ ] Removing all content (empty markdown) gracefully hides the prose section
- [ ] Network failure on the content fetch does not break the events list

🤖 Generated with [Claude Code](https://claude.com/claude-code)