### PR TITLE
fix: expose home content page in admin editor

### DIFF
--- a/apps/web/src/features/admin/screens/content/AdminContentEditorScreen.tsx
+++ b/apps/web/src/features/admin/screens/content/AdminContentEditorScreen.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { ContentEditor } from '../../../../pages/ContentPage';
 
 const EDITABLE_SLUGS = new Set([
+  'home',
   'about',
   'faq',
   'contact',

--- a/apps/web/src/features/admin/screens/content/AdminContentHomeScreen.tsx
+++ b/apps/web/src/features/admin/screens/content/AdminContentHomeScreen.tsx
@@ -16,6 +16,7 @@ const contentGroups: ContentGroup[] = [
   {
     title: 'About',
     links: [
+      { label: 'Home', to: '/admin/content/home', pathLabel: '/' },
       { label: 'About', to: '/admin/content/about', pathLabel: '/about' },
       { label: 'FAQ', to: '/admin/content/faq', pathLabel: '/about/FAQ' },
     ],


### PR DESCRIPTION
## Summary
Follow-up to #31 — the admin editor fix commit was pushed to that PR branch after it had already been merged, so it was not included.

- Adds `'home'` to `EDITABLE_SLUGS` in `AdminContentEditorScreen` so navigating to `/admin/content/home` renders the editor rather than "Unknown content page"
- Adds a **Home** link card to the About group in `AdminContentHomeScreen` so the page is discoverable

## Test plan
- [ ] Admin → Content → About → **Home** card is visible
- [ ] Clicking it opens the content editor for the landing page intro
- [ ] Saving updates what appears on the homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)