### PR TITLE
feat(challenge): improve challenge event flow

### DIFF
--- a/apps/api/src/modules/events/event.routes.ts
+++ b/apps/api/src/modules/events/event.routes.ts
@@ -40,6 +40,7 @@ import {
   extractReplayHistoryGames,
   normalizeReplayEndCondition,
 } from '../replay/replay-parse';
+import { createGameResult, type ZeroReason } from '../results/result.service';
 
 const router = Router();
 
@@ -608,250 +609,103 @@ router.post(
       body.template_id ?? body.templateId ?? (req.query.template_id as string | undefined);
     const template_id = templateIdRaw != null ? Number(templateIdRaw) : undefined;
     const { replay } = body;
-    let step = 'start';
-
-    console.log('[validate-replay] start', {
-      slug,
-      teamId,
-      template_id,
-      replaySnippet: replay?.slice?.(0, 100),
-    });
 
     if (!template_id || Number.isNaN(template_id) || !replay) {
-      console.warn('[validate-replay] missing fields', { template_id, replayPresent: !!replay });
       return res.status(400).json({ error: 'template_id and replay are required' });
     }
-
     const gameId = parseGameId(replay);
     if (!gameId) {
-      console.warn('[validate-replay] parse fail', { replay });
       return res.status(400).json({ error: 'Unable to parse game id from replay/link' });
     }
-
     const teamIdNum = Number(teamId);
     if (!Number.isInteger(teamIdNum)) {
       return res.status(400).json({ error: 'Invalid team id' });
     }
 
+    const result = await runReplayValidation(slug, teamIdNum, template_id, gameId);
+    if (!result.ok) {
+      const e = result as ReplayValidationError;
+      return res.status(e.statusCode).json(e.body);
+    }
+    const ok = result as ReplayValidationSuccess;
+    return res.json({
+      ok: true,
+      gameId: ok.gameId,
+      export: { players: ok.exportPlayers, seed: ok.seedString },
+      derived: ok.derived,
+    });
+  },
+);
+
+/* ------------------------------------------
+ *  POST /api/events/:slug/teams/:teamId/submit-replay
+ *  Validate a replay and record the result in one call
+ * ----------------------------------------*/
+router.post(
+  '/:slug/teams/:teamId/submit-replay',
+  authRequired,
+  async (req: AuthenticatedRequest, res: Response) => {
+    const slug = String(req.params.slug);
+    const teamId = String(req.params.teamId);
+    const body = req.body as {
+      template_id?: number;
+      replay?: string;
+      bottom_deck_risk?: number | null;
+      notes?: string | null;
+    };
+    const template_id = body.template_id != null ? Number(body.template_id) : undefined;
+    const { replay, bottom_deck_risk = null, notes = null } = body;
+
+    if (!template_id || Number.isNaN(template_id) || !replay) {
+      return res.status(400).json({ error: 'template_id and replay are required' });
+    }
+    const gameId = parseGameId(replay);
+    if (!gameId) {
+      return res.status(400).json({ error: 'Unable to parse game id from replay/link' });
+    }
+    const teamIdNum = Number(teamId);
+    if (!Number.isInteger(teamIdNum)) {
+      return res.status(400).json({ error: 'Invalid team id' });
+    }
+
+    const validation = await runReplayValidation(slug, teamIdNum, template_id, gameId);
+    if (!validation.ok) {
+      const e = validation as ReplayValidationError;
+      return res.status(e.statusCode).json(e.body);
+    }
+
+    const { derived, exportPlayers, teamId: resolvedTeamId } = validation as ReplayValidationSuccess;
+
+    if (derived.score == null) {
+      return res
+        .status(400)
+        .json({ error: 'Could not determine score from replay. Submit manually.' });
+    }
+
+    const zeroReason = endConditionToZeroReason(derived.endCondition);
+
     try {
-      step = 'lookup event';
-      const eventId = await getEventId(slug);
-      if (!eventId) return res.status(404).json({ error: 'Event not found' });
-      console.log('[validate-replay] event', { eventId });
-
-      step = 'lookup team';
-      const teamResult = await pool.query(
-        `
-      SELECT id, team_size, event_id
-      FROM event_teams
-      WHERE id = $1 AND event_id = $2;
-      `,
-        [teamIdNum, eventId],
-      );
-      if (teamResult.rowCount === 0) {
-        return res.status(404).json({ error: 'Team not found for this event' });
-      }
-      const team = teamResult.rows[0] as { id: number; team_size: number; event_id: number };
-      console.log('[validate-replay] team', { team });
-
-      step = 'lookup template';
-      const tplResult = await pool.query(
-        `
-      SELECT egt.id, egt.seed_payload, egt.variant, es.event_id, es.config_json
-      FROM event_game_templates egt
-      JOIN event_stages es ON es.event_stage_id = egt.event_stage_id
-      WHERE egt.id = $1;
-      `,
-        [template_id],
-      );
-      if (tplResult.rowCount === 0) {
-        return res.status(404).json({ error: 'Template not found' });
-      }
-      const tpl = tplResult.rows[0] as {
-        id: number;
-        seed_payload: string | null;
-        variant: string;
-        event_id: number;
-        config_json: unknown;
-      };
-      if (tpl.event_id !== eventId) {
-        return res.status(400).json({ error: 'Template does not belong to this event' });
-      }
-      console.log('[validate-replay] template', { tpl });
-
-      const members = await listTeamMembers(team.id);
-      const teamPlayerPool = members.filter((m) => m.role === 'PLAYER').map((m) => m.display_name);
-      const stageConfig =
-        tpl.config_json && typeof tpl.config_json === 'object' && !Array.isArray(tpl.config_json)
-          ? (tpl.config_json as { enforce_exact_team_size?: unknown })
-          : {};
-      const enforceExactTeamMatch = stageConfig.enforce_exact_team_size === true;
-      console.log('[validate-replay] members', teamPlayerPool, {
-        enforceExactTeamMatch,
+      const row = await createGameResult({
+        event_team_id: resolvedTeamId,
+        event_game_template_id: template_id,
+        game_id: Number(gameId),
+        score: derived.score,
+        zero_reason: zeroReason,
+        bottom_deck_risk: bottom_deck_risk != null ? Number(bottom_deck_risk) : null,
+        notes: notes ?? null,
+        played_at: derived.playedAt ?? null,
+        players: exportPlayers,
       });
-
-      // Stage 1: fetch export and validate players/seed/size
-      step = 'fetch export';
-      const exportJson = await fetchJsonWithTimeout(`https://hanab.live/export/${gameId}`);
-      console.log('[validate-replay] export fetched', {
-        keys: Object.keys(exportJson ?? {}),
-        players: exportJson?.players ?? exportJson?.playerNames ?? exportJson?.player_names,
-        seed: exportJson?.seed,
-      });
-      if (!exportJson || typeof exportJson !== 'object') {
-        return res.status(400).json({ error: 'Invalid export payload from hanab.live' });
-      }
-      const exportPlayers = extractReplayExportPlayers(exportJson);
-      if (!exportPlayers || exportPlayers.length === 0) {
-        return res.status(400).json({ error: 'Replay export is missing a valid players list' });
-      }
-      const seedString = exportJson.seed ?? '';
-
-      const duplicatePlayers = exportPlayers.filter(
-        (player) =>
-          exportPlayers.findIndex((candidate: string) => candidate === player) !==
-          exportPlayers.lastIndexOf(player),
-      );
-      if (duplicatePlayers.length > 0) {
-        return res.status(400).json({
-          error: `Replay includes duplicate players: ${[...new Set(duplicatePlayers)].join(', ')}`,
-        });
-      }
-
-      const nonPoolPlayers = exportPlayers.filter((p) => !teamPlayerPool.includes(p));
-      if (nonPoolPlayers.length > 0) {
-        return res.status(400).json({
-          error: `Replay includes players not in this team pool: ${nonPoolPlayers.join(', ')}`,
-        });
-      }
-      if (enforceExactTeamMatch) {
-        const missingPlayers = teamPlayerPool.filter((p) => !exportPlayers.includes(p));
-        if (missingPlayers.length > 0 || exportPlayers.length !== teamPlayerPool.length) {
-          return res.status(400).json({
-            error: `Replay team must exactly match registered team players: ${teamPlayerPool.join(', ')}`,
-          });
-        }
-      }
-
-      // Check seed and player count from seed string
-      const seedMatch = seedString.match(/p(\d+)v\d+s([A-Za-z0-9]+)/);
-      if (!seedMatch) {
-        return res.status(400).json({ error: 'Seed string from replay is not in expected format' });
-      }
-      const seedPlayers = Number(seedMatch[1]);
-      const seedSuffix = seedMatch[2];
-      console.log('[validate-replay] seed parsed', { seedPlayers, seedSuffix });
-      if (seedPlayers !== team.team_size) {
-        return res
-          .status(400)
-          .json({ error: `Replay is for ${seedPlayers}p but team is ${team.team_size}p` });
-      }
-      if (tpl.seed_payload && seedSuffix !== tpl.seed_payload) {
-        return res.status(400).json({
-          error: `Replay seed ${seedSuffix} does not match template seed ${tpl.seed_payload}`,
-        });
-      }
-
-      // Stage 2: fetch history-full for first player and check variant/flags/score
-      let historyData: unknown = null;
-      if (exportPlayers.length > 0) {
-        const player = exportPlayers[0];
-        step = 'fetch history';
-        historyData = await fetchJsonWithTimeout(
-          `https://hanab.live/api/v1/history-full/${encodeURIComponent(player)}?start=${gameId}&end=${gameId}`,
-        );
-        console.log('[validate-replay] history fetched', {
-          player,
-          keys: historyData ? Object.keys(historyData) : [],
-          array: Array.isArray(historyData),
-        });
-      }
-
-      let historyVariant = null;
-      let flagsOk = true;
-      let score: number | null = null;
-      let endCondition: number | null = null;
-      let playedAt: string | null = null;
-
-      // history-full returns an array for single-user queries. For multi-user it can be {games: []}
-      const historyGames = extractReplayHistoryGames<ReplayHistoryGame>(historyData);
-
-      if (historyGames.length > 0) {
-        const game = historyGames.find(
-          (g: ReplayHistoryGame) => String(g.id ?? g.gameId ?? g.game_id) === String(gameId),
-        );
-        if (game) {
-          const opts = game.options ?? {};
-          historyVariant = game.variantName ?? opts.variantName ?? game.variant ?? opts.variant;
-          const flags = {
-            cardCycle: game.cardCycle ?? opts.cardCycle,
-            deckPlays: game.deckPlays ?? opts.deckPlays,
-            emptyClues: game.emptyClues ?? opts.emptyClues,
-            oneExtraCard: game.oneExtraCard ?? opts.oneExtraCard,
-            oneLessCard: game.oneLessCard ?? opts.oneLessCard,
-            allOrNothing: game.allOrNothing ?? opts.allOrNothing,
-            detrimentalCharacters: game.detrimentalCharacters ?? opts.detrimentalCharacters,
-          };
-          flagsOk = Object.values(flags).every((v) => v === false || v === undefined);
-          score = game.score == null ? null : Number(game.score);
-          endCondition = normalizeReplayEndCondition(game.endCondition);
-          playedAt =
-            game.datetimeFinished ?? game.datetimeFinishedUtc ?? game.datetime_finished ?? null;
-        }
-      }
-
-      if (historyVariant && historyVariant !== tpl.variant) {
-        return res.status(400).json({
-          error: `Replay variant ${historyVariant} does not match template variant ${tpl.variant}`,
-        });
-      }
-      if (!flagsOk) {
-        return res
-          .status(400)
-          .json({ error: 'Replay uses unsupported optional rules (flags should be false)' });
-      }
-
-      console.log('[validate-replay] success', {
-        gameId,
-        exportPlayers,
-        seedString,
-        derived: { seedSuffix, seedPlayers, historyVariant, score, endCondition, playedAt },
-      });
-
-      return res.json({
-        ok: true,
-        gameId,
-        export: {
-          players: exportPlayers,
-          seed: seedString,
-        },
-        derived: {
-          seedSuffix,
-          teamSize: seedPlayers,
-          variant: historyVariant ?? tpl.variant,
-          score,
-          endCondition,
-          playedAt,
-        },
-      });
+      return res.status(201).json(row);
     } catch (err) {
-      const e = err as { message?: string; code?: string; stack?: string };
-      const message = e.message ?? 'Failed to validate replay';
-      if (message === 'timeout') {
-        return res.status(504).json({
-          error: 'Validation timed out contacting hanab.live',
-          code: 'TIMEOUT',
-          details: message,
-          step,
-        });
+      const e = err as { code?: string };
+      if (e.code === 'GAME_RESULT_EXISTS') {
+        return res
+          .status(409)
+          .json({ error: 'A game result already exists for this team and template' });
       }
-      console.error('Error validating replay:', err);
-      res.status(502).json({
-        error: `Failed to validate replay: ${message}`,
-        code: e.code ?? 'FETCH_FAILED',
-        details: e.stack ?? String(err),
-        step,
-      });
+      console.error('[submit-replay] error creating result', err);
+      return res.status(500).json({ error: 'Failed to record game result' });
     }
   },
 );
@@ -881,6 +735,227 @@ function parseGameId(input: string | null | undefined): string | null {
   const matchUrl = trimmed.match(/(?:replay|shared-replay)\/(\d+)/i);
   const matchId = trimmed.match(/^\d+$/);
   return matchUrl ? matchUrl[1] : matchId ? matchId[0] : null;
+}
+
+function endConditionToZeroReason(code: number | null): ZeroReason {
+  if (code === 2) return 'Strike Out';
+  if (code === 3) return 'Time Out';
+  if (code === 4 || code === 10) return 'VTK';
+  return null;
+}
+
+type ReplayValidationSuccess = {
+  ok: true;
+  gameId: string;
+  teamId: number;
+  exportPlayers: string[];
+  seedString: string;
+  derived: {
+    seedSuffix: string;
+    teamSize: number;
+    variant: string;
+    score: number | null;
+    endCondition: number | null;
+    playedAt: string | null;
+  };
+};
+
+type ReplayValidationError = {
+  ok: false;
+  statusCode: number;
+  body: { error: string; code?: string; details?: string; step?: string };
+};
+
+async function runReplayValidation(
+  slug: string,
+  teamIdNum: number,
+  template_id: number,
+  gameId: string,
+): Promise<ReplayValidationSuccess | ReplayValidationError> {
+  let step = 'start';
+
+  const err = (
+    statusCode: number,
+    error: string,
+    extra?: { code?: string; details?: string },
+  ): ReplayValidationError => ({ ok: false, statusCode, body: { error, step, ...extra } });
+
+  try {
+    step = 'lookup event';
+    const eventId = await getEventId(slug);
+    if (!eventId) return err(404, 'Event not found');
+
+    step = 'lookup team';
+    const teamResult = await pool.query(
+      `SELECT id, team_size, event_id FROM event_teams WHERE id = $1 AND event_id = $2`,
+      [teamIdNum, eventId],
+    );
+    if (teamResult.rowCount === 0) return err(404, 'Team not found for this event');
+    const team = teamResult.rows[0] as { id: number; team_size: number; event_id: number };
+
+    step = 'lookup template';
+    const tplResult = await pool.query(
+      `SELECT egt.id, egt.seed_payload, egt.variant, es.event_id, es.config_json
+       FROM event_game_templates egt
+       JOIN event_stages es ON es.event_stage_id = egt.event_stage_id
+       WHERE egt.id = $1`,
+      [template_id],
+    );
+    if (tplResult.rowCount === 0) return err(404, 'Template not found');
+    const tpl = tplResult.rows[0] as {
+      id: number;
+      seed_payload: string | null;
+      variant: string;
+      event_id: number;
+      config_json: unknown;
+    };
+    if (tpl.event_id !== eventId) return err(400, 'Template does not belong to this event');
+
+    const members = await listTeamMembers(team.id);
+    const teamPlayerPool = members.filter((m) => m.role === 'PLAYER').map((m) => m.display_name);
+    const stageConfig =
+      tpl.config_json && typeof tpl.config_json === 'object' && !Array.isArray(tpl.config_json)
+        ? (tpl.config_json as { enforce_exact_team_size?: unknown })
+        : {};
+    const enforceExactTeamMatch = stageConfig.enforce_exact_team_size === true;
+
+    // Stage 1: fetch export and validate players/seed/size
+    step = 'fetch export';
+    const exportJson = await fetchJsonWithTimeout(`https://hanab.live/export/${gameId}`);
+    if (!exportJson || typeof exportJson !== 'object') {
+      return err(400, 'Invalid export payload from hanab.live');
+    }
+    const exportPlayers = extractReplayExportPlayers(exportJson);
+    if (!exportPlayers || exportPlayers.length === 0) {
+      return err(400, 'Replay export is missing a valid players list');
+    }
+    const seedString = (exportJson as { seed?: string }).seed ?? '';
+
+    const duplicatePlayers = exportPlayers.filter(
+      (p) =>
+        exportPlayers.findIndex((c: string) => c === p) !== exportPlayers.lastIndexOf(p),
+    );
+    if (duplicatePlayers.length > 0) {
+      return err(
+        400,
+        `Replay includes duplicate players: ${[...new Set(duplicatePlayers)].join(', ')}`,
+      );
+    }
+
+    const nonPoolPlayers = exportPlayers.filter((p) => !teamPlayerPool.includes(p));
+    if (nonPoolPlayers.length > 0) {
+      return err(
+        400,
+        `Replay includes players not in this team pool: ${nonPoolPlayers.join(', ')}`,
+      );
+    }
+    if (enforceExactTeamMatch) {
+      const missingPlayers = teamPlayerPool.filter((p) => !exportPlayers.includes(p));
+      if (missingPlayers.length > 0 || exportPlayers.length !== teamPlayerPool.length) {
+        return err(
+          400,
+          `Replay team must exactly match registered team players: ${teamPlayerPool.join(', ')}`,
+        );
+      }
+    }
+
+    const seedMatch = seedString.match(/p(\d+)v\d+s([A-Za-z0-9]+)/);
+    if (!seedMatch) {
+      return err(400, 'Seed string from replay is not in expected format');
+    }
+    const seedPlayers = Number(seedMatch[1]);
+    const seedSuffix = seedMatch[2];
+
+    if (seedPlayers !== team.team_size) {
+      return err(400, `Replay is for ${seedPlayers}p but team is ${team.team_size}p`);
+    }
+    if (tpl.seed_payload && seedSuffix !== tpl.seed_payload) {
+      return err(
+        400,
+        `Replay seed ${seedSuffix} does not match template seed ${tpl.seed_payload}`,
+      );
+    }
+
+    // Stage 2: fetch history-full for first player and check variant/flags/score
+    let historyData: unknown = null;
+    if (exportPlayers.length > 0) {
+      step = 'fetch history';
+      historyData = await fetchJsonWithTimeout(
+        `https://hanab.live/api/v1/history-full/${encodeURIComponent(exportPlayers[0])}?start=${gameId}&end=${gameId}`,
+      );
+    }
+
+    let historyVariant: string | null = null;
+    let flagsOk = true;
+    let score: number | null = null;
+    let endCondition: number | null = null;
+    let playedAt: string | null = null;
+
+    const historyGames = extractReplayHistoryGames<ReplayHistoryGame>(historyData);
+    if (historyGames.length > 0) {
+      const game = historyGames.find(
+        (g: ReplayHistoryGame) => String(g.id ?? g.gameId ?? g.game_id) === String(gameId),
+      );
+      if (game) {
+        const opts = game.options ?? {};
+        historyVariant = game.variantName ?? opts.variantName ?? game.variant ?? opts.variant ?? null;
+        const flags = {
+          cardCycle: game.cardCycle ?? opts.cardCycle,
+          deckPlays: game.deckPlays ?? opts.deckPlays,
+          emptyClues: game.emptyClues ?? opts.emptyClues,
+          oneExtraCard: game.oneExtraCard ?? opts.oneExtraCard,
+          oneLessCard: game.oneLessCard ?? opts.oneLessCard,
+          allOrNothing: game.allOrNothing ?? opts.allOrNothing,
+          detrimentalCharacters: game.detrimentalCharacters ?? opts.detrimentalCharacters,
+        };
+        flagsOk = Object.values(flags).every((v) => v === false || v === undefined);
+        score = game.score == null ? null : Number(game.score);
+        endCondition = normalizeReplayEndCondition(game.endCondition);
+        playedAt =
+          game.datetimeFinished ?? game.datetimeFinishedUtc ?? game.datetime_finished ?? null;
+      }
+    }
+
+    if (historyVariant && historyVariant !== tpl.variant) {
+      return err(
+        400,
+        `Replay variant ${historyVariant} does not match template variant ${tpl.variant}`,
+      );
+    }
+    if (!flagsOk) {
+      return err(400, 'Replay uses unsupported optional rules (flags should be false)');
+    }
+
+    return {
+      ok: true,
+      gameId,
+      teamId: team.id,
+      exportPlayers,
+      seedString,
+      derived: {
+        seedSuffix,
+        teamSize: seedPlayers,
+        variant: historyVariant ?? tpl.variant,
+        score,
+        endCondition,
+        playedAt,
+      },
+    };
+  } catch (caughtErr) {
+    const e = caughtErr as { message?: string; code?: string; stack?: string };
+    const message = e.message ?? 'Failed to validate replay';
+    if (message === 'timeout') {
+      return err(504, 'Validation timed out contacting hanab.live', {
+        code: 'TIMEOUT',
+        details: message,
+      });
+    }
+    console.error('[runReplayValidation] error', caughtErr);
+    return err(502, `Failed to validate replay: ${message}`, {
+      code: e.code ?? 'FETCH_FAILED',
+      details: e.stack ?? String(caughtErr),
+    });
+  }
 }
 /* ------------------------------------------
  *  POST /api/events  (ADMIN)

--- a/apps/api/src/modules/events/event.routes.ts
+++ b/apps/api/src/modules/events/event.routes.ts
@@ -674,7 +674,11 @@ router.post(
       return res.status(e.statusCode).json(e.body);
     }
 
-    const { derived, exportPlayers, teamId: resolvedTeamId } = validation as ReplayValidationSuccess;
+    const {
+      derived,
+      exportPlayers,
+      teamId: resolvedTeamId,
+    } = validation as ReplayValidationSuccess;
 
     if (derived.score == null) {
       return res
@@ -832,8 +836,7 @@ async function runReplayValidation(
     const seedString = (exportJson as { seed?: string }).seed ?? '';
 
     const duplicatePlayers = exportPlayers.filter(
-      (p) =>
-        exportPlayers.findIndex((c: string) => c === p) !== exportPlayers.lastIndexOf(p),
+      (p) => exportPlayers.findIndex((c: string) => c === p) !== exportPlayers.lastIndexOf(p),
     );
     if (duplicatePlayers.length > 0) {
       return err(
@@ -870,10 +873,7 @@ async function runReplayValidation(
       return err(400, `Replay is for ${seedPlayers}p but team is ${team.team_size}p`);
     }
     if (tpl.seed_payload && seedSuffix !== tpl.seed_payload) {
-      return err(
-        400,
-        `Replay seed ${seedSuffix} does not match template seed ${tpl.seed_payload}`,
-      );
+      return err(400, `Replay seed ${seedSuffix} does not match template seed ${tpl.seed_payload}`);
     }
 
     // Stage 2: fetch history-full for first player and check variant/flags/score
@@ -898,7 +898,8 @@ async function runReplayValidation(
       );
       if (game) {
         const opts = game.options ?? {};
-        historyVariant = game.variantName ?? opts.variantName ?? game.variant ?? opts.variant ?? null;
+        historyVariant =
+          game.variantName ?? opts.variantName ?? game.variant ?? opts.variant ?? null;
         const flags = {
           cardCycle: game.cardCycle ?? opts.cardCycle,
           deckPlays: game.deckPlays ?? opts.deckPlays,

--- a/apps/web/src/design-system/index.ts
+++ b/apps/web/src/design-system/index.ts
@@ -45,6 +45,8 @@ export { ActionIcon, Indicator, Menu, PasswordInput, ScrollArea, SimpleGrid } fr
 // Core wrapper exports for pages/features that need lower-level primitives.
 // Use these via design-system (not direct ../mantine imports) to preserve a single UI boundary.
 export {
+  Combobox as CoreCombobox,
+  useCombobox as useCoreCombobox,
   ActionIcon as CoreActionIcon,
   Alert as CoreAlert,
   Anchor as CoreAnchor,

--- a/apps/web/src/features/teams/team-page/gameRows.tsx
+++ b/apps/web/src/features/teams/team-page/gameRows.tsx
@@ -453,15 +453,6 @@ export function UnplayedRow({
     }
   };
 
-  const zeroReasonFromEndCondition = (
-    code: number | null | undefined,
-  ): 'Strike Out' | 'Time Out' | 'VTK' | null => {
-    if (code === 2) return 'Strike Out';
-    if (code === 3) return 'Time Out';
-    if (code === 4 || code === 10) return 'VTK';
-    return null;
-  };
-
   const handleSubmit = async () => {
     if (!editable) return;
     setSubmitError(null);
@@ -469,34 +460,28 @@ export function UnplayedRow({
       setSubmitError('Not authenticated.');
       return;
     }
-    if (!draft.replayGameId || draft.validateStatus !== 'ok') {
-      setSubmitError('Validate the replay first.');
-      return;
-    }
-    if (draft.derivedScore == null) {
-      setSubmitError('Missing score from validation.');
+    if (!draft.replay) {
+      setSubmitError('Enter a game ID or replay URL.');
       return;
     }
 
     setSubmitting(true);
     try {
-      await postJsonAuth('/results', token, {
-        event_team_id: teamId,
-        event_game_template_id: template.template_id,
-        game_id: Number(draft.replayGameId),
-        score: draft.derivedScore,
-        zero_reason: zeroReasonFromEndCondition(draft.derivedEndConditionCode),
-        bottom_deck_risk: draft.bdr ? Number(draft.bdr) : null,
-        notes: draft.notes || null,
-        played_at: draft.derivedPlayedAt ?? null,
-        players: draft.derivedPlayers ?? [],
-      });
+      await postJsonAuth(
+        `/events/${encodeURIComponent(slug)}/teams/${teamId}/submit-replay`,
+        token,
+        {
+          template_id: template.template_id,
+          replay: draft.replay,
+          bottom_deck_risk: draft.bdr ? Number(draft.bdr) : null,
+          notes: draft.notes || null,
+        },
+      );
       window.location.reload();
     } catch (err) {
+      const body = err instanceof ApiError ? (err.body as { error?: string }) : null;
       const message =
-        err instanceof ApiError
-          ? ((err.body as { error?: string })?.error ?? `Submit failed (status ${err.status})`)
-          : ((err as Error)?.message ?? 'Submit failed');
+        body?.error ?? (err instanceof ApiError ? `Submit failed (status ${err.status})` : ((err as Error)?.message ?? 'Submit failed'));
       setSubmitError(message);
     } finally {
       setSubmitting(false);
@@ -583,12 +568,7 @@ export function UnplayedRow({
               <Button
                 variant="primary"
                 size="sm"
-                disabled={
-                  !draft.replayGameId ||
-                  Boolean(draft.replayError) ||
-                  draft.validateStatus !== 'ok' ||
-                  submitting
-                }
+                disabled={!draft.replay || Boolean(draft.replayError) || submitting}
                 onClick={handleSubmit}
                 aria-label="Submit"
               >

--- a/apps/web/src/features/teams/team-page/gameRows.tsx
+++ b/apps/web/src/features/teams/team-page/gameRows.tsx
@@ -481,7 +481,10 @@ export function UnplayedRow({
     } catch (err) {
       const body = err instanceof ApiError ? (err.body as { error?: string }) : null;
       const message =
-        body?.error ?? (err instanceof ApiError ? `Submit failed (status ${err.status})` : ((err as Error)?.message ?? 'Submit failed'));
+        body?.error ??
+        (err instanceof ApiError
+          ? `Submit failed (status ${err.status})`
+          : ((err as Error)?.message ?? 'Submit failed'));
       setSubmitError(message);
     } finally {
       setSubmitting(false);

--- a/apps/web/src/mantine.tsx
+++ b/apps/web/src/mantine.tsx
@@ -1,4 +1,6 @@
 import {
+  Combobox as MantineCombobox,
+  useCombobox as useMantineCombobox,
   ActionIcon as MantineActionIcon,
   Alert as MantineAlert,
   Anchor as MantineAnchor,
@@ -217,6 +219,8 @@ export function SimpleGrid(props: SimpleGridProps): ReactElement {
 }
 
 // Preserve compound APIs (e.g., Menu.Target, Grid.Col, Table.Tbody, List.Item, Radio.Group).
+export const Combobox = MantineCombobox;
+export const useCombobox = useMantineCombobox;
 export const Menu = MantineMenu;
 export const Grid = MantineGrid;
 export const Table = MantineTable;

--- a/apps/web/src/pages/admin/AdminBadgeDesignerPage.tsx
+++ b/apps/web/src/pages/admin/AdminBadgeDesignerPage.tsx
@@ -17,7 +17,7 @@ import {
   CoreTitle as Title,
 } from '../../design-system';
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import { ApiError } from '../../lib/api';
 import {
@@ -72,6 +72,8 @@ export function AdminBadgeDesignerPage() {
   const auth = useAuth();
   const navigate = useNavigate();
   const { badgeSetId } = useParams<{ badgeSetId: string }>();
+  const [searchParams] = useSearchParams();
+  const returnTo = searchParams.get('returnTo');
   const [shape, setShape] = useState<BadgeShape>('circle');
   const [tier, setTier] = useState<TierKey>('gold');
   const [tierConfig, setTierConfig] = useState<Record<TierKey, TierConfig>>(DEFAULT_TIER_CONFIG);
@@ -280,7 +282,11 @@ export function AdminBadgeDesignerPage() {
       setBadgeSetName(name);
       setSaveNotice(forceNew ? 'Saved as new set.' : 'Saved.');
       setSaveError(null);
-      navigate(`/admin/badges/${String(created.id)}/edit`, { replace: true });
+      if (returnTo) {
+        navigate(returnTo, { replace: true });
+      } else {
+        navigate(`/admin/badges/${String(created.id)}/edit`, { replace: true });
+      }
     } catch (err) {
       if (err instanceof ApiError) {
         const body = err.body as { error?: string } | null;
@@ -349,9 +355,15 @@ export function AdminBadgeDesignerPage() {
           <Button variant="light" onClick={openSaveAs}>
             Save As
           </Button>
-          <Button component={Link} to="/admin/badges" variant="subtle">
-            Back To Badge Sets
-          </Button>
+          {returnTo ? (
+            <Button component={Link} to={returnTo} variant="subtle">
+              Back to Event Wizard
+            </Button>
+          ) : (
+            <Button component={Link} to="/admin/badges" variant="subtle">
+              Back To Badge Sets
+            </Button>
+          )}
         </Group>
       </Stack>
 

--- a/apps/web/src/pages/admin/AdminCreateEventPage.tsx
+++ b/apps/web/src/pages/admin/AdminCreateEventPage.tsx
@@ -119,11 +119,12 @@ function VariantCombobox({
       <Combobox.Dropdown>
         <Combobox.Options mah={260} style={{ overflowY: 'auto' }}>
           {loading && <Combobox.Empty>Loading…</Combobox.Empty>}
-          {!loading && filtered.map((v) => (
-            <Combobox.Option key={v} value={v}>
-              {v}
-            </Combobox.Option>
-          ))}
+          {!loading &&
+            filtered.map((v) => (
+              <Combobox.Option key={v} value={v}>
+                {v}
+              </Combobox.Option>
+            ))}
           {!loading && filtered.length === 0 && value.trim() && !exactMatch && (
             <Combobox.Option value={value}>Use &quot;{value}&quot;</Combobox.Option>
           )}
@@ -1384,9 +1385,7 @@ export function AdminCreateEventPage() {
                               isEdit && editSlug
                                 ? `/admin/events/${editSlug}/edit`
                                 : '/admin/events/create';
-                            navigate(
-                              `/admin/badges/new?returnTo=${encodeURIComponent(returnTo)}`,
-                            );
+                            navigate(`/admin/badges/new?returnTo=${encodeURIComponent(returnTo)}`);
                           }}
                         >
                           Open Badge Designer

--- a/apps/web/src/pages/admin/AdminCreateEventPage.tsx
+++ b/apps/web/src/pages/admin/AdminCreateEventPage.tsx
@@ -37,6 +37,7 @@ import {
   type BadgeSetRecord,
   updateChallengeBadgeConfigAuth,
 } from './badgeSetsApi';
+import { CoreCombobox as Combobox, useCoreCombobox as useCombobox } from '../../design-system';
 import {
   CREATE_EVENT_WIZARD_DRAFT_KEY,
   initialStage,
@@ -61,6 +62,93 @@ import {
   getStageAbbrForSeeds,
   slugify,
 } from '../../features/admin/event-wizard/helpers';
+
+const HANABI_VARIANTS = [
+  'No Variant',
+  'Rainbow',
+  'Pink',
+  'White',
+  'Brown',
+  'Null',
+  'Muddy Rainbow',
+  'Dark Rainbow',
+  'Dark Pink',
+  'Dark White',
+  'Dark Brown',
+  'Dark Null',
+  'Dark Muddy Rainbow',
+  'Black',
+  'Purple',
+  'Gray',
+  'Gray Pink',
+  'Light Pink',
+  'Prism',
+  'Dark Prism',
+  'Omni',
+  'Dark Omni',
+  'Critical Fours',
+  'Alternating Clues',
+  'Clue Starved',
+  'Color Blind',
+  'Number Blind',
+  'Totally Blind',
+  'Color Mute',
+  'Number Mute',
+  'Throw It in a Hole',
+  'Reversed',
+  'Up or Down',
+  'Cow & Pig',
+  'Duck',
+];
+
+function VariantCombobox({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const combobox = useCombobox({ onDropdownClose: () => combobox.resetSelectedOption() });
+  const filtered = HANABI_VARIANTS.filter((v) =>
+    v.toLowerCase().includes(value.toLowerCase().trim()),
+  );
+  const exactMatch = HANABI_VARIANTS.some((v) => v.toLowerCase() === value.toLowerCase().trim());
+
+  return (
+    <Combobox
+      store={combobox}
+      onOptionSubmit={(v) => {
+        onChange(v);
+        combobox.closeDropdown();
+      }}
+    >
+      <Combobox.Target>
+        <TextInput
+          label="Variant"
+          value={value}
+          onChange={(e) => {
+            onChange(e.currentTarget.value);
+            combobox.openDropdown();
+            combobox.updateSelectedOptionIndex();
+          }}
+          onClick={() => combobox.openDropdown()}
+          onFocus={() => combobox.openDropdown()}
+          onBlur={() => combobox.closeDropdown()}
+          required
+        />
+      </Combobox.Target>
+      <Combobox.Dropdown>
+        <Combobox.Options>
+          {filtered.map((v) => (
+            <Combobox.Option key={v} value={v}>
+              {v}
+            </Combobox.Option>
+          ))}
+          {filtered.length === 0 && value.trim() && !exactMatch && (
+            <Combobox.Option value={value}>Use &quot;{value}&quot;</Combobox.Option>
+          )}
+          {filtered.length === 0 && !value.trim() && (
+            <Combobox.Empty>No variants found</Combobox.Empty>
+          )}
+        </Combobox.Options>
+      </Combobox.Dropdown>
+    </Combobox>
+  );
+}
 
 export function AdminCreateEventPage() {
   const { user, token } = useAuth();
@@ -135,7 +223,7 @@ export function AdminCreateEventPage() {
     }
 
     if (isChallenge) {
-      return ['type', 'event', 'registration', 'stage', 'templates', 'badges']
+      return ['type', 'event', 'registration', 'templates', 'badges']
         .map((key) => stepByKey.get(key as StepKey))
         .filter((step): step is { key: StepKey; label: string } => Boolean(step));
     }
@@ -761,19 +849,20 @@ export function AdminCreateEventPage() {
     !formulaHasSpace &&
     !tournamentLimitError;
 
-  const stageValid = isSessionLadder
-    ? true
-    : stages.length > 0 &&
-      stages.every((stage) => {
-        const hasSpace = /\s/.test(stage.abbr);
-        return (
-          Boolean(stage.label) &&
-          Boolean(stage.abbr) &&
-          !hasSpace &&
-          stage.gameCount > 0 &&
-          (stage.timeBound ? datesValid(stage.startsAt, stage.endsAt) : true)
-        );
-      });
+  const stageValid =
+    isSessionLadder || isChallenge
+      ? true
+      : stages.length > 0 &&
+        stages.every((stage) => {
+          const hasSpace = /\s/.test(stage.abbr);
+          return (
+            Boolean(stage.label) &&
+            Boolean(stage.abbr) &&
+            !hasSpace &&
+            stage.gameCount > 0 &&
+            (stage.timeBound ? datesValid(stage.startsAt, stage.endsAt) : true)
+          );
+        });
 
   const templatesValid = isSessionLadder
     ? true
@@ -1522,12 +1611,7 @@ export function AdminCreateEventPage() {
                         </Alert>
                       ) : (
                         <>
-                          <TextInput
-                            label="Variant"
-                            value={variant}
-                            onChange={(e) => setVariant(e.currentTarget.value)}
-                            required
-                          />
+                          <VariantCombobox value={variant} onChange={setVariant} />
 
                           <NumberInput
                             label="Number of games"
@@ -1543,16 +1627,6 @@ export function AdminCreateEventPage() {
                             onChange={(e) => setSeedFormula(e.currentTarget.value)}
                             placeholder="{eID}-{rID}-{i}"
                             required
-                            rightSection={
-                              <Button
-                                type="button"
-                                variant="subtle"
-                                size="compact-xs"
-                                onClick={() => setShowFormulaHelp(true)}
-                              >
-                                Info
-                              </Button>
-                            }
                             error={
                               formulaHasSpace
                                 ? 'Formula cannot contain spaces.'
@@ -1561,6 +1635,14 @@ export function AdminCreateEventPage() {
                                   : undefined
                             }
                           />
+                          <Button
+                            type="button"
+                            variant="subtle"
+                            size="compact-xs"
+                            onClick={() => setShowFormulaHelp(true)}
+                          >
+                            Formula reference
+                          </Button>
 
                           {invalidTokens.length > 0 && (
                             <Alert color="red" variant="light">

--- a/apps/web/src/pages/admin/AdminCreateEventPage.tsx
+++ b/apps/web/src/pages/admin/AdminCreateEventPage.tsx
@@ -862,7 +862,6 @@ export function AdminCreateEventPage() {
     Boolean(longDescription) &&
     Boolean(eventAbbr) &&
     !abbrHasSpace &&
-    !formulaHasSpace &&
     !tournamentLimitError;
 
   const stageValid =
@@ -1598,23 +1597,16 @@ export function AdminCreateEventPage() {
                         <Badge variant="light">{`Step ${activeStepIndex + 1} of ${stepOrder.length}`}</Badge>
                       </Group>
 
-                      {isSessionLadder ? (
-                        <Alert color="blue" variant="light">
-                          League events do not use fixed stages/templates. Configure sessions and
-                          rounds after creation from the League controls.
-                        </Alert>
-                      ) : (
-                        stages.map((stage, idx) => (
-                          <StageBlock
-                            key={idx}
-                            stage={stage}
-                            index={idx}
-                            parsedMaxTeams={parsedMaxTeams}
-                            seedingFormat={seedingFormat}
-                            onPatch={updateStage}
-                          />
-                        ))
-                      )}
+                      {stages.map((stage, idx) => (
+                        <StageBlock
+                          key={idx}
+                          stage={stage}
+                          index={idx}
+                          parsedMaxTeams={parsedMaxTeams}
+                          seedingFormat={seedingFormat}
+                          onPatch={updateStage}
+                        />
+                      ))}
                     </Stack>
                   </SectionCard>
                 )}

--- a/apps/web/src/pages/admin/AdminCreateEventPage.tsx
+++ b/apps/web/src/pages/admin/AdminCreateEventPage.tsx
@@ -68,10 +68,10 @@ let cachedVariants: string[] | null = null;
 
 async function fetchHanabVariants(): Promise<string[]> {
   if (cachedVariants) return cachedVariants;
-  const resp = await fetch('https://hanab.live/api/v1/variants');
+  const resp = await fetch('/api/variants');
   if (!resp.ok) throw new Error(`Failed to fetch variants (${resp.status})`);
-  const data = (await resp.json()) as Record<string, string>;
-  const sorted = Object.values(data).sort((a, b) => a.localeCompare(b));
+  const data = (await resp.json()) as { variants: { name: string }[] };
+  const sorted = data.variants.map((v) => v.name).sort((a, b) => a.localeCompare(b));
   cachedVariants = sorted;
   return sorted;
 }
@@ -195,7 +195,9 @@ export function AdminCreateEventPage() {
   const [hanabVariantsLoading, setHanabVariantsLoading] = useState(false);
 
   const hasLoadedExisting = useRef(false);
+  const prevEditSlugRef = useRef<string | undefined>(undefined);
   const previousEventTypeRef = useRef<EventTypeLabel>('Challenge');
+  const hanabVariantsFetchInitiated = useRef(false);
 
   const isTournament = eventType === 'Tournament';
   const isSessionLadder = eventType === 'League';
@@ -544,27 +546,31 @@ export function AdminCreateEventPage() {
 
   useEffect(() => {
     if (currentStep !== 'templates' || isSessionLadder) return;
-    if (hanabVariants.length > 0 || hanabVariantsLoading) return;
-    let cancelled = false;
+    if (hanabVariants.length > 0 || hanabVariantsFetchInitiated.current) return;
+    hanabVariantsFetchInitiated.current = true;
     const load = async () => {
       setHanabVariantsLoading(true);
       try {
         const variants = await fetchHanabVariants();
-        if (!cancelled) setHanabVariants(variants);
+        setHanabVariants(variants);
       } catch {
         // fall through — user can still type a custom value
       } finally {
-        if (!cancelled) setHanabVariantsLoading(false);
+        setHanabVariantsLoading(false);
       }
     };
     void load();
-    return () => {
-      cancelled = true;
-    };
-  }, [currentStep, isSessionLadder, hanabVariants.length, hanabVariantsLoading]);
+  }, [currentStep, isSessionLadder, hanabVariants.length]);
 
   useEffect(() => {
-    if (!isEdit || !editSlug || hasLoadedExisting.current) return;
+    if (!isEdit || !editSlug) return;
+
+    if (prevEditSlugRef.current !== editSlug) {
+      prevEditSlugRef.current = editSlug;
+      hasLoadedExisting.current = false;
+    }
+
+    if (hasLoadedExisting.current) return;
 
     const load = async () => {
       setLoadingExisting(true);
@@ -687,6 +693,7 @@ export function AdminCreateEventPage() {
         setChallengeBadgeSetId(challengeLink ? String(challengeLink.badge_set_id) : null);
         setLeagueSeasonBadgeSetId(seasonLink ? String(seasonLink.badge_set_id) : null);
         setLeagueSessionBadgeSetId(sessionLink ? String(sessionLink.badge_set_id) : null);
+        setCurrentStep('event');
       } catch (err) {
         if (err instanceof ApiError) {
           setError(`Failed to load event for editing: ${extractApiErrorMessage(err)}`);
@@ -1062,7 +1069,7 @@ export function AdminCreateEventPage() {
         }
       }
 
-      if (!isSessionLadder) {
+      if (!isEdit && !isSessionLadder) {
         for (let idx = 0; idx < stages.length; idx += 1) {
           const stage = stages[idx];
           const stagePayload = await postJsonAuth<{ event_stage_id: number }>(
@@ -1374,7 +1381,13 @@ export function AdminCreateEventPage() {
                           variant="light"
                           onClick={() => {
                             saveWizardDraft();
-                            navigate('/admin/badges/new');
+                            const returnTo =
+                              isEdit && editSlug
+                                ? `/admin/events/${editSlug}/edit`
+                                : '/admin/events/create';
+                            navigate(
+                              `/admin/badges/new?returnTo=${encodeURIComponent(returnTo)}`,
+                            );
                           }}
                         >
                           Open Badge Designer
@@ -1706,7 +1719,7 @@ export function AdminCreateEventPage() {
                       Previous
                     </Button>
 
-                    {currentIndex < stepOrder.length - 1 ? (
+                    {currentIndex < stepOrder.length - 1 && (
                       <Button
                         type="button"
                         onClick={onNext}
@@ -1714,27 +1727,27 @@ export function AdminCreateEventPage() {
                       >
                         Next
                       </Button>
-                    ) : (
-                      <Button
-                        type="submit"
-                        disabled={
-                          !eventValid ||
-                          !badgesValid ||
-                          !registrationValid ||
-                          !stageValid ||
-                          !templatesValid ||
-                          saving
-                        }
-                      >
-                        {saving
-                          ? isEdit
-                            ? 'Saving...'
-                            : 'Creating...'
-                          : isEdit
-                            ? 'Save Event'
-                            : 'Create Event'}
-                      </Button>
                     )}
+
+                    <Button
+                      type="submit"
+                      disabled={
+                        !eventValid ||
+                        !badgesValid ||
+                        !registrationValid ||
+                        !stageValid ||
+                        !templatesValid ||
+                        saving
+                      }
+                    >
+                      {saving
+                        ? isEdit
+                          ? 'Saving...'
+                          : 'Creating...'
+                        : isEdit
+                          ? 'Save Event'
+                          : 'Create Event'}
+                    </Button>
                   </Group>
                 </Group>
               </Stack>

--- a/apps/web/src/pages/admin/AdminCreateEventPage.tsx
+++ b/apps/web/src/pages/admin/AdminCreateEventPage.tsx
@@ -63,50 +63,34 @@ import {
   slugify,
 } from '../../features/admin/event-wizard/helpers';
 
-const HANABI_VARIANTS = [
-  'No Variant',
-  'Rainbow',
-  'Pink',
-  'White',
-  'Brown',
-  'Null',
-  'Muddy Rainbow',
-  'Dark Rainbow',
-  'Dark Pink',
-  'Dark White',
-  'Dark Brown',
-  'Dark Null',
-  'Dark Muddy Rainbow',
-  'Black',
-  'Purple',
-  'Gray',
-  'Gray Pink',
-  'Light Pink',
-  'Prism',
-  'Dark Prism',
-  'Omni',
-  'Dark Omni',
-  'Critical Fours',
-  'Alternating Clues',
-  'Clue Starved',
-  'Color Blind',
-  'Number Blind',
-  'Totally Blind',
-  'Color Mute',
-  'Number Mute',
-  'Throw It in a Hole',
-  'Reversed',
-  'Up or Down',
-  'Cow & Pig',
-  'Duck',
-];
+// Module-level cache so we only fetch once per page session.
+let cachedVariants: string[] | null = null;
 
-function VariantCombobox({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+async function fetchHanabVariants(): Promise<string[]> {
+  if (cachedVariants) return cachedVariants;
+  const resp = await fetch('https://hanab.live/api/v1/variants');
+  if (!resp.ok) throw new Error(`Failed to fetch variants (${resp.status})`);
+  const data = (await resp.json()) as Record<string, string>;
+  const sorted = Object.values(data).sort((a, b) => a.localeCompare(b));
+  cachedVariants = sorted;
+  return sorted;
+}
+
+function VariantCombobox({
+  value,
+  onChange,
+  variants,
+  loading,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  variants: string[];
+  loading?: boolean;
+}) {
   const combobox = useCombobox({ onDropdownClose: () => combobox.resetSelectedOption() });
-  const filtered = HANABI_VARIANTS.filter((v) =>
-    v.toLowerCase().includes(value.toLowerCase().trim()),
-  );
-  const exactMatch = HANABI_VARIANTS.some((v) => v.toLowerCase() === value.toLowerCase().trim());
+  const trimmed = value.toLowerCase().trim();
+  const filtered = variants.filter((v) => v.toLowerCase().includes(trimmed));
+  const exactMatch = variants.some((v) => v.toLowerCase() === trimmed);
 
   return (
     <Combobox
@@ -120,6 +104,7 @@ function VariantCombobox({ value, onChange }: { value: string; onChange: (v: str
         <TextInput
           label="Variant"
           value={value}
+          placeholder={loading ? 'Loading variants…' : 'Search variants…'}
           onChange={(e) => {
             onChange(e.currentTarget.value);
             combobox.openDropdown();
@@ -132,16 +117,17 @@ function VariantCombobox({ value, onChange }: { value: string; onChange: (v: str
         />
       </Combobox.Target>
       <Combobox.Dropdown>
-        <Combobox.Options>
-          {filtered.map((v) => (
+        <Combobox.Options mah={260} style={{ overflowY: 'auto' }}>
+          {loading && <Combobox.Empty>Loading…</Combobox.Empty>}
+          {!loading && filtered.map((v) => (
             <Combobox.Option key={v} value={v}>
               {v}
             </Combobox.Option>
           ))}
-          {filtered.length === 0 && value.trim() && !exactMatch && (
+          {!loading && filtered.length === 0 && value.trim() && !exactMatch && (
             <Combobox.Option value={value}>Use &quot;{value}&quot;</Combobox.Option>
           )}
-          {filtered.length === 0 && !value.trim() && (
+          {!loading && filtered.length === 0 && !value.trim() && (
             <Combobox.Empty>No variants found</Combobox.Empty>
           )}
         </Combobox.Options>
@@ -205,6 +191,8 @@ export function AdminCreateEventPage() {
   const [loadingExisting, setLoadingExisting] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [hanabVariants, setHanabVariants] = useState<string[]>([]);
+  const [hanabVariantsLoading, setHanabVariantsLoading] = useState(false);
 
   const hasLoadedExisting = useRef(false);
   const previousEventTypeRef = useRef<EventTypeLabel>('Challenge');
@@ -553,6 +541,27 @@ export function AdminCreateEventPage() {
       cancelled = true;
     };
   }, [token, isUnauthorized]);
+
+  useEffect(() => {
+    if (currentStep !== 'templates' || isSessionLadder) return;
+    if (hanabVariants.length > 0 || hanabVariantsLoading) return;
+    let cancelled = false;
+    const load = async () => {
+      setHanabVariantsLoading(true);
+      try {
+        const variants = await fetchHanabVariants();
+        if (!cancelled) setHanabVariants(variants);
+      } catch {
+        // fall through — user can still type a custom value
+      } finally {
+        if (!cancelled) setHanabVariantsLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentStep, isSessionLadder, hanabVariants.length, hanabVariantsLoading]);
 
   useEffect(() => {
     if (!isEdit || !editSlug || hasLoadedExisting.current) return;
@@ -1611,7 +1620,12 @@ export function AdminCreateEventPage() {
                         </Alert>
                       ) : (
                         <>
-                          <VariantCombobox value={variant} onChange={setVariant} />
+                          <VariantCombobox
+                            value={variant}
+                            onChange={setVariant}
+                            variants={hanabVariants}
+                            loading={hanabVariantsLoading}
+                          />
 
                           <NumberInput
                             label="Number of games"

--- a/apps/web/src/pages/admin/AdminEventsIndexPage.tsx
+++ b/apps/web/src/pages/admin/AdminEventsIndexPage.tsx
@@ -112,7 +112,6 @@ export function AdminEventsIndexPage() {
                 key={event.id}
                 title={event.name}
                 subtitle={event.short_description}
-                href={`/events/${encodeURIComponent(event.slug)}`}
                 actions={
                   <Group gap={4} wrap="nowrap">
                     <Tooltip label={event.published ? 'Unpublish' : 'Publish'}>

--- a/docs/standards/design-system.md
+++ b/docs/standards/design-system.md
@@ -1,0 +1,72 @@
+# Design System Standards
+
+## Overview
+
+`apps/web/src/design-system/` exports two tiers of components. Using the wrong tier, or bypassing the design system entirely with native HTML, is an error.
+
+## Tier 1: First-Party Design System Components
+
+Imported as plain names from `'../design-system'` (or relative equivalent):
+
+```tsx
+import { Button, Alert, Text, Input, Select } from '../design-system';
+```
+
+These are custom-built components with controlled prop surfaces. `Button` uses a generic `as` prop pattern and inherits native HTML attributes (including `type`, `disabled`, etc.) via `ComponentPropsWithoutRef<T>`.
+
+Use Tier 1 components in page and feature code wherever they cover the use case.
+
+## Tier 2: Core* Mantine Wrappers
+
+Imported with the `Core` prefix from `'../../design-system'`:
+
+```tsx
+import {
+  CoreButton as Button,
+  CoreBox as Box,
+  CoreText as Text,
+  CoreAlert as Alert,
+} from '../../design-system';
+```
+
+These are raw Mantine components re-exported through the design system boundary (to avoid direct `../mantine` imports in pages). Their TypeScript types are Mantine's own prop definitions, which differ from the first-party wrappers.
+
+### Rules for Core* Components
+
+- **Do not pass `type="button"` or `type="submit"`** to `CoreButton`. Mantine's `ButtonProps` does not include `type` in its public surface.
+- **Do not pass `children` as a prop attribute** to `CoreBox`, `CoreText`, or similar layout primitives. Use JSX children syntax instead.
+- **Do not pass `alt`** as a typed prop to `CoreImage`.
+- **Do not pass `variant="light"`** to `CoreAlert`. Mantine uses its own `AlertVariant` union; check Mantine docs for valid values.
+- Before adding any prop to a Core* component, verify it exists in Mantine's type definition for that component. When in doubt, look at how the same component is used elsewhere in the same file.
+
+Admin pages (`apps/web/src/pages/admin/`) use Core* components. Non-admin pages generally use Tier 1 components.
+
+## No Native HTML as Substitutes
+
+Do not use raw HTML elements (`<button>`, `<input>`, `<select>`, `<div>`) where a design system component exists. This applies to both tiers.
+
+**Wrong:**
+```tsx
+<button type="button" onClick={handleClick}>Cancel</button>
+```
+
+**Right (Tier 1):**
+```tsx
+<Button variant="secondary" onClick={handleClick}>Cancel</Button>
+```
+
+**Right (Core*, inside a Mantine-driven admin page):**
+```tsx
+<Button variant="default" onClick={handleClick}>Cancel</Button>
+```
+
+## Atomicity
+
+- Extract repeated UI patterns into shared components rather than copying markup.
+- Page components orchestrate; they do not own business logic or repeated rendering primitives.
+- New UI patterns should reuse or extend existing design system atoms before introducing variants.
+- See [code-style.md](./code-style.md) for general atomicity expectations.
+
+## Imports
+
+- Always import through `'../../design-system'` (or relative equivalent), never directly from `'../../mantine'` or the Mantine package itself. This preserves the single UI boundary and ensures the design system can evolve independently.


### PR DESCRIPTION
## Summary

- **Consolidated replay submit** — replaces the two-step validate-then-POST-/results flow with a single `POST /events/:slug/teams/:teamId/submit-replay` endpoint that validates and records atomically. Inline validation on input still runs for UX feedback, but the submit button now fires one call. The `validate-replay` logic was extracted into a shared `runReplayValidation` helper used by both routes.
- **Removed stage step from challenge wizard** — challenges are always single-stage; the stage is auto-created from event dates and template config. The wizard steps for Challenge are now: Type → Event → Registration → Templates → Badges.
- **Variant combobox** — the free-text variant input is replaced with a searchable combobox offering 35 common hanab.live variants. Typing filters the list; any unlisted value can still be entered directly.
- **Seed formula Info button** — moved out of the \`rightSection\` (cramped, non-obvious) to a standalone "Formula reference" button directly below the input.

## Test plan

- [ ] Create a challenge event end-to-end in the admin wizard — confirm no stage step appears, variant combobox works, formula reference button opens the modal
- [ ] As a team member, submit a replay — confirm a single network call to \`submit-replay\` records the result; inline validation still shows the checkmark before submit
- [ ] Verify validation errors (wrong seed, wrong players, bad flags) surface correctly on submit
- [ ] Edit an existing challenge event — variant should pre-fill correctly in the combobox

🤖 Generated with [Claude Code](https://claude.com/claude-code)