### PR TITLE
chore(infra): speed up Render builds with corepack and filtered installs

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
-    buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/web run build
+    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/web... && pnpm -C apps/web run build
     staticPublishPath: ./apps/web/dist
     domains:
       - hanabi-challenges.com
@@ -36,7 +36,7 @@ services:
           property: connectionString
       - key: JWT_SECRET
         sync: false
-    buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/api run build
+    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
     startCommand: node apps/api/dist/src/scripts/bootstrap-db.js && node apps/api/dist/src/index.js
     healthCheckPath: /health
     domains:


### PR DESCRIPTION
## Summary

- Replace `npx -y pnpm@10.30.3` with `corepack enable && corepack prepare pnpm@10.30.3 --activate` — corepack ships with Node 22 and caches the pnpm binary between deploys, eliminating a ~30-60s re-download on every build
- Scope each service's `pnpm install` with `--filter` so the frontend only installs web+shared deps and the API only installs api+shared deps, skipping unrelated packages

## Test plan

- [ ] Verify frontend deploys successfully on Render after merge
- [ ] Verify API deploys successfully on Render after merge
- [ ] Confirm deploy time is meaningfully reduced vs baseline (~12 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)