### PR TITLE
fix: UI regressions, CI pnpm setup, and packageManager version

### DIFF
--- a/.github/workflows/ci-battery.yml
+++ b/.github/workflows/ci-battery.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.30.3
+          version: 10.31.0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci-battery.yml
+++ b/.github/workflows/ci-battery.yml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.31.0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/apps/web/src/design-system/components/layout/Card/Card.css
+++ b/apps/web/src/design-system/components/layout/Card/Card.css
@@ -132,6 +132,7 @@
   box-shadow: var(--ds-elevation-3, 0 6px 16px rgba(0, 0, 0, 0.12));
   transform: translateY(-1px);
   background-color: color-mix(in srgb, var(--ds-color-accent-weak) 25%, var(--ds-color-surface));
+  color: var(--ds-color-text);
 }
 .ui-card--interactive.ui-card--suppress-hover:hover {
   box-shadow: none;

--- a/apps/web/src/design-system/components/typography/Prose/Prose.css
+++ b/apps/web/src/design-system/components/typography/Prose/Prose.css
@@ -32,6 +32,6 @@
 }
 
 .ds-prose a {
-  color: var(--ds-color-accent-strong);
+  color: var(--color-accent);
   text-decoration: underline;
 }

--- a/apps/web/src/mantine.tsx
+++ b/apps/web/src/mantine.tsx
@@ -11,6 +11,7 @@ import {
   Card as MantineCard,
   Checkbox as MantineCheckbox,
   Code as MantineCode,
+  createTheme,
   Divider as MantineDivider,
   Grid as MantineGrid,
   Group as MantineGroup,
@@ -79,9 +80,30 @@ import {
 } from '@mantine/core';
 import type { ReactElement } from 'react';
 
+// Align Mantine's primary color with the design system's blue palette so
+// variant="light" / variant="subtle" buttons use the correct accent color.
+const theme = createTheme({
+  primaryColor: 'blue',
+  primaryShade: 6,
+  colors: {
+    blue: [
+      '#eff6ff', // 0 — blue-50
+      '#dbeafe', // 1 — blue-100 / accent-weak
+      '#bfdbfe', // 2 — blue-200
+      '#93c5fd', // 3 — blue-300
+      '#60a5fa', // 4 — blue-400
+      '#3b82f6', // 5 — blue-500
+      '#2563eb', // 6 — blue-600 / --color-accent  ← primary
+      '#1d4ed8', // 7 — blue-700 / --color-accent-strong
+      '#1e40af', // 8 — blue-800
+      '#1e3a8a', // 9 — blue-900
+    ],
+  },
+});
+
 // Centralized Mantine wrappers with stable defaults so pages/features only invoke primitives.
 export function MantineProvider(props: MantineProviderProps): ReactElement {
-  return <MantineProviderCore {...props} />;
+  return <MantineProviderCore theme={theme} {...props} />;
 }
 
 export function Card(props: CardProps): ReactElement {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@10.31.0+sha512.e3927388bfaa8078ceb79b748ffc1e8274e84d75163e67bc22e06c0d3aed43dd153151cbf11d7f8301ff4acb98c68bdc5cadf6989532801ffafe3b3e4a63c268",
   "engines": {
     "node": "22.x"
   },

--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
-    buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/web run build
+    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/web... && pnpm -C apps/web run build
     staticPublishPath: ./apps/web/dist
     domains:
       - hanabi-challenges.com
@@ -36,7 +36,7 @@ services:
           property: connectionString
       - key: JWT_SECRET
         sync: false
-    buildCommand: npx -y pnpm@10.30.3 install --frozen-lockfile && npx -y pnpm@10.30.3 -C apps/api run build
+    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
     startCommand: node apps/api/dist/src/scripts/bootstrap-db.js && node apps/api/dist/src/index.js
     healthCheckPath: /health
     domains:

--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
-    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/web... && pnpm -C apps/web run build
+    buildCommand: corepack enable && corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/web... && pnpm -C apps/web run build
     staticPublishPath: ./apps/web/dist
     domains:
       - hanabi-challenges.com
@@ -36,7 +36,7 @@ services:
           property: connectionString
       - key: JWT_SECRET
         sync: false
-    buildCommand: corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
+    buildCommand: corepack enable && corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
     startCommand: node apps/api/dist/src/scripts/bootstrap-db.js && node apps/api/dist/src/index.js
     healthCheckPath: /health
     domains:


### PR DESCRIPTION
## Summary
- Fix three UI regressions: card hover text turns blue, prose link color mismatch, muted button gray text (Mantine theme alignment)
- Fix CI pnpm setup: remove explicit `version` from `pnpm/action-setup@v4` to avoid conflict with `packageManager` field in `package.json`
- Bump `packageManager` field to `pnpm@10.31.0` (with integrity hash) to match `render.yaml`

## Test plan
- [ ] CI battery passes
- [ ] Verify card hover description text stays `--ds-color-text` (not blue)
- [ ] Verify prose links match global link color (`--color-accent`)
- [ ] Verify Mantine `variant="light"` buttons use blue accent, not gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)