### PR TITLE
feat(ds): Skeleton primitive and companion skeleton components

### DIFF
--- a/apps/web/src/design-system/components/data-display/Badge/BadgeSkeleton.tsx
+++ b/apps/web/src/design-system/components/data-display/Badge/BadgeSkeleton.tsx
@@ -1,0 +1,36 @@
+import type { ReactElement } from 'react';
+import { Skeleton } from '../../feedback/Skeleton/Skeleton';
+import type { BadgeSize } from './Badge';
+
+type BadgeSkeletonProps = {
+  size?: BadgeSize;
+  width?: string | number;
+  animate?: boolean;
+  className?: string;
+};
+
+const heightBySize: Record<BadgeSize, string> = {
+  sm: '18px',
+  md: '22px',
+};
+
+/**
+ * BadgeSkeleton
+ * Pill-shaped shimmer placeholder matching Badge dimensions.
+ */
+export function BadgeSkeleton({
+  size = 'md',
+  width = 64,
+  animate = true,
+  className,
+}: BadgeSkeletonProps): ReactElement {
+  return (
+    <Skeleton
+      width={width}
+      height={heightBySize[size]}
+      radius="var(--ds-radius-pill)"
+      animate={animate}
+      className={className}
+    />
+  );
+}

--- a/apps/web/src/design-system/components/data-display/KPIText/KPITextSkeleton.tsx
+++ b/apps/web/src/design-system/components/data-display/KPIText/KPITextSkeleton.tsx
@@ -1,0 +1,41 @@
+import type { ReactElement } from 'react';
+import { Skeleton } from '../../feedback/Skeleton/Skeleton';
+
+type KPITextSkeletonProps = {
+  size?: 'sm' | 'md' | 'lg';
+  /** Show a label line above the value. */
+  showLabel?: boolean;
+  /** Show a subtext line below the value. */
+  showSubtext?: boolean;
+  animate?: boolean;
+  className?: string;
+};
+
+const valueHeightBySize: Record<'sm' | 'md' | 'lg', string> = {
+  sm: '24px',
+  md: '34px',
+  lg: '48px',
+};
+
+/**
+ * KPITextSkeleton
+ * Shimmer placeholder matching KPIText's label / value / subtext layout.
+ */
+export function KPITextSkeleton({
+  size = 'md',
+  showLabel = true,
+  showSubtext = false,
+  animate = true,
+  className,
+}: KPITextSkeletonProps): ReactElement {
+  return (
+    <div
+      className={className}
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-xxs)' }}
+    >
+      {showLabel && <Skeleton width={80} height="12px" animate={animate} />}
+      <Skeleton width={60} height={valueHeightBySize[size]} animate={animate} />
+      {showSubtext && <Skeleton width={100} height="12px" animate={animate} />}
+    </div>
+  );
+}

--- a/apps/web/src/design-system/components/data-display/Pill/PillSkeleton.tsx
+++ b/apps/web/src/design-system/components/data-display/Pill/PillSkeleton.tsx
@@ -1,0 +1,37 @@
+import type { ReactElement } from 'react';
+import { Skeleton } from '../../feedback/Skeleton/Skeleton';
+import type { PillSize } from './Pill';
+
+type PillSkeletonProps = {
+  size?: PillSize;
+  width?: string | number;
+  animate?: boolean;
+  className?: string;
+};
+
+const heightBySize: Record<PillSize, string> = {
+  sm: '24px',
+  md: '32px',
+  lg: '36px',
+};
+
+/**
+ * PillSkeleton
+ * Pill-shaped shimmer placeholder matching Pill dimensions.
+ */
+export function PillSkeleton({
+  size = 'md',
+  width = 80,
+  animate = true,
+  className,
+}: PillSkeletonProps): ReactElement {
+  return (
+    <Skeleton
+      width={width}
+      height={heightBySize[size]}
+      radius="var(--ds-radius-pill)"
+      animate={animate}
+      className={className}
+    />
+  );
+}

--- a/apps/web/src/design-system/components/data-display/Table/TableSkeleton.tsx
+++ b/apps/web/src/design-system/components/data-display/Table/TableSkeleton.tsx
@@ -1,0 +1,79 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { Skeleton } from '../../feedback/Skeleton/Skeleton';
+
+type TableSkeletonProps = {
+  rows?: number;
+  cols?: number;
+  density?: 'relaxed' | 'tight';
+  animate?: boolean;
+  className?: string;
+};
+
+/**
+ * TableSkeleton
+ * Renders a table-shaped shimmer placeholder with a header row and data rows.
+ */
+export function TableSkeleton({
+  rows = 5,
+  cols = 4,
+  density = 'relaxed',
+  animate = true,
+  className,
+}: TableSkeletonProps): ReactElement {
+  const tight = density === 'tight';
+  const cellPaddingV = tight ? 'var(--ds-space-xxs)' : 'var(--ds-space-xs)';
+  const cellPaddingH = tight ? 'var(--ds-space-xs)' : 'var(--ds-space-sm)';
+  const cellHeight = tight ? '12px' : '14px';
+
+  const cellStyle: CSSProperties = {
+    padding: `${cellPaddingV} ${cellPaddingH}`,
+    borderBottom: '1px solid var(--ds-color-border)',
+  };
+
+  const headerCellStyle: CSSProperties = {
+    ...cellStyle,
+    background: 'var(--ds-color-surface-muted)',
+  };
+
+  return (
+    <div
+      className={className}
+      style={{
+        borderRadius: 'var(--ds-radius-sm)',
+        border: '1px solid var(--ds-color-border)',
+        overflow: 'hidden',
+      }}
+    >
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          <tr>
+            {Array.from({ length: cols }, (_, i) => (
+              <th key={i} style={headerCellStyle}>
+                <Skeleton
+                  width={`${55 + ((i * 23) % 30)}%`}
+                  height={cellHeight}
+                  animate={animate}
+                />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: rows }, (_, r) => (
+            <tr key={r}>
+              {Array.from({ length: cols }, (_, c) => (
+                <td key={c} style={cellStyle}>
+                  <Skeleton
+                    width={`${45 + (((r + c) * 17) % 40)}%`}
+                    height={cellHeight}
+                    animate={animate}
+                  />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/design-system/components/feedback/Skeleton/Skeleton.tsx
+++ b/apps/web/src/design-system/components/feedback/Skeleton/Skeleton.tsx
@@ -1,0 +1,37 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { Skeleton as MantineSkeleton } from '../../../../mantine';
+
+export type SkeletonProps = {
+  width?: CSSProperties['width'];
+  height?: CSSProperties['height'];
+  /** Defaults to pill (999px) for inline elements, or ds-radius-sm for blocks. */
+  radius?: string | number;
+  animate?: boolean;
+  circle?: boolean;
+  className?: string;
+};
+
+/**
+ * Skeleton
+ * Base shimmer placeholder for loading states. All *Skeleton companion
+ * components are built on top of this primitive.
+ */
+export function Skeleton({
+  width,
+  height = '1em',
+  radius = 'var(--ds-radius-sm)',
+  animate = true,
+  circle = false,
+  className,
+}: SkeletonProps): ReactElement {
+  return (
+    <MantineSkeleton
+      width={width as string}
+      height={height as string}
+      radius={radius as string}
+      animate={animate}
+      circle={circle}
+      className={className}
+    />
+  );
+}

--- a/apps/web/src/design-system/components/layout/Card/CardSkeleton.tsx
+++ b/apps/web/src/design-system/components/layout/Card/CardSkeleton.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+import { Skeleton } from '../../feedback/Skeleton/Skeleton';
+import { Card } from './Card';
+import type { CardVariant, CardPadding } from './Card';
+
+type CardSkeletonProps = {
+  /** Number of body text lines. */
+  lines?: number;
+  variant?: CardVariant;
+  padding?: CardPadding;
+  /** Show a heading-sized skeleton at the top. */
+  showHeader?: boolean;
+  /** Show a footer row (e.g. action buttons). */
+  showFooter?: boolean;
+  animate?: boolean;
+  className?: string;
+};
+
+/**
+ * CardSkeleton
+ * Renders a Card shell filled with shimmer lines — useful for list/grid
+ * loading states where card count is known but content is not yet fetched.
+ */
+export function CardSkeleton({
+  lines = 3,
+  variant = 'elevated',
+  padding = 'md',
+  showHeader = true,
+  showFooter = false,
+  animate = true,
+  className,
+}: CardSkeletonProps): ReactElement {
+  return (
+    <Card variant={variant} padding={padding} className={className}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-sm)' }}>
+        {showHeader && <Skeleton width="55%" height="22px" animate={animate} />}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-xs)' }}>
+          {Array.from({ length: lines }, (_, i) => (
+            <Skeleton
+              key={i}
+              width={i === lines - 1 ? '60%' : '90%'}
+              height="14px"
+              animate={animate}
+            />
+          ))}
+        </div>
+        {showFooter && (
+          <div
+            style={{ display: 'flex', gap: 'var(--ds-space-xs)', marginTop: 'var(--ds-space-xs)' }}
+          >
+            <Skeleton width={80} height="32px" radius="var(--ds-radius-md)" animate={animate} />
+            <Skeleton width={64} height="32px" radius="var(--ds-radius-md)" animate={animate} />
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/design-system/components/layout/PageHeader/PageHeaderSkeleton.tsx
+++ b/apps/web/src/design-system/components/layout/PageHeader/PageHeaderSkeleton.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from 'react';
+import { Skeleton } from '../../feedback/Skeleton/Skeleton';
+import { Inline } from '../Inline/Inline';
+
+type PageHeaderSkeletonProps = {
+  level?: 1 | 2 | 3 | 4;
+  /** Show a subtitle line below the title. */
+  showSubtitle?: boolean;
+  /** Show an action placeholder on the right. */
+  showActions?: boolean;
+  actionsWidth?: number;
+  animate?: boolean;
+  className?: string;
+};
+
+const titleHeightByLevel: Record<1 | 2 | 3 | 4, string> = {
+  1: '40px',
+  2: '32px',
+  3: '26px',
+  4: '22px',
+};
+
+/**
+ * PageHeaderSkeleton
+ * Shimmer placeholder matching PageHeader's title / subtitle / actions layout.
+ */
+export function PageHeaderSkeleton({
+  level = 1,
+  showSubtitle = true,
+  showActions = false,
+  actionsWidth = 120,
+  animate = true,
+  className,
+}: PageHeaderSkeletonProps): ReactElement {
+  return (
+    <Inline
+      justify="space-between"
+      align="start"
+      wrap
+      style={{ width: '100%' }}
+      className={className}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-xs)' }}>
+        <Skeleton width="45%" height={titleHeightByLevel[level]} animate={animate} />
+        {showSubtitle && <Skeleton width="65%" height="14px" animate={animate} />}
+      </div>
+      {showActions && (
+        <Skeleton
+          width={actionsWidth}
+          height="32px"
+          radius="var(--ds-radius-md)"
+          animate={animate}
+        />
+      )}
+    </Inline>
+  );
+}

--- a/apps/web/src/design-system/components/typography/Heading/HeadingSkeleton.tsx
+++ b/apps/web/src/design-system/components/typography/Heading/HeadingSkeleton.tsx
@@ -1,0 +1,35 @@
+import type { ReactElement } from 'react';
+import { Skeleton } from '../../feedback/Skeleton/Skeleton';
+import type { HeadingLevel } from './Heading';
+
+type HeadingSkeletonProps = {
+  level?: HeadingLevel;
+  width?: string | number;
+  animate?: boolean;
+  className?: string;
+};
+
+/** Approximate rendered height per heading level, matching textStyles tokens. */
+const heightByLevel: Record<HeadingLevel, string> = {
+  1: '40px',
+  2: '32px',
+  3: '26px',
+  4: '22px',
+  5: '20px',
+  6: '18px',
+};
+
+/**
+ * HeadingSkeleton
+ * Shimmer placeholder sized to match a Heading at the given level.
+ */
+export function HeadingSkeleton({
+  level = 2,
+  width = '55%',
+  animate = true,
+  className,
+}: HeadingSkeletonProps): ReactElement {
+  return (
+    <Skeleton width={width} height={heightByLevel[level]} animate={animate} className={className} />
+  );
+}

--- a/apps/web/src/design-system/components/typography/Text/TextSkeleton.tsx
+++ b/apps/web/src/design-system/components/typography/Text/TextSkeleton.tsx
@@ -1,0 +1,59 @@
+import type { ReactElement } from 'react';
+import { Skeleton } from '../../feedback/Skeleton/Skeleton';
+import type { TextVariant } from './Text';
+
+type TextSkeletonProps = {
+  /** Number of lines to render. */
+  lines?: number;
+  /**
+   * Width of each line. A single value applies to all lines; an array
+   * sets per-line widths (last line conventionally shorter).
+   */
+  width?: string | number | (string | number)[];
+  variant?: TextVariant;
+  animate?: boolean;
+  className?: string;
+};
+
+const heightByVariant: Record<TextVariant, string> = {
+  body: '14px',
+  muted: '14px',
+  subtle: '14px',
+  label: '12px',
+  caption: '12px',
+  overline: '12px',
+};
+
+/**
+ * TextSkeleton
+ * Shimmer placeholder that mirrors the height of Text variants.
+ */
+export function TextSkeleton({
+  lines = 1,
+  width,
+  variant = 'body',
+  animate = true,
+  className,
+}: TextSkeletonProps): ReactElement {
+  const height = heightByVariant[variant];
+
+  if (lines === 1) {
+    const w = Array.isArray(width) ? (width[0] ?? '75%') : (width ?? '75%');
+    return <Skeleton width={w} height={height} animate={animate} className={className} />;
+  }
+
+  const widths = Array.isArray(width)
+    ? width
+    : Array.from({ length: lines }, (_, i) => (i === lines - 1 ? '50%' : (width ?? '90%')));
+
+  return (
+    <div
+      className={className}
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-space-xs)' }}
+    >
+      {Array.from({ length: lines }, (_, i) => (
+        <Skeleton key={i} width={widths[i] ?? '90%'} height={height} animate={animate} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/design-system/index.ts
+++ b/apps/web/src/design-system/index.ts
@@ -1,7 +1,9 @@
 export { Card } from './components/layout/Card/Card';
 export { CardHeader, CardBody, CardFooter } from './components/layout/Card/CardSections';
+export { CardSkeleton } from './components/layout/Card/CardSkeleton';
 export { SectionCard } from './components/layout/SectionCard/SectionCard';
 export { PageHeader } from './components/layout/PageHeader/PageHeader';
+export { PageHeaderSkeleton } from './components/layout/PageHeader/PageHeaderSkeleton';
 export { CardContainer } from './components/layout/CardContainer/CardContainer';
 export { PageContainer } from './components/layout/PageContainer/PageContainer';
 export { Section } from './components/layout/Section/Section';
@@ -14,16 +16,23 @@ export { Button } from './components/inputs/Button/Button';
 export { Checkbox } from './components/inputs/Checkbox/Checkbox';
 export { Radio } from './components/inputs/Radio/Radio';
 export { Alert } from './components/feedback/Alert/Alert';
+export { Skeleton } from './components/feedback/Skeleton/Skeleton';
 export { Input } from './components/inputs/Input/Input';
 export { Pill } from './components/data-display/Pill/Pill';
+export { PillSkeleton } from './components/data-display/Pill/PillSkeleton';
 export { Badge } from './components/data-display/Badge/Badge';
+export { BadgeSkeleton } from './components/data-display/Badge/BadgeSkeleton';
 export { MaterialIcon } from './components/data-display/MaterialIcon/MaterialIcon';
 export { Table } from './components/data-display/Table/Table';
+export { TableSkeleton } from './components/data-display/Table/TableSkeleton';
 export { KPIText } from './components/data-display/KPIText/KPIText';
+export { KPITextSkeleton } from './components/data-display/KPIText/KPITextSkeleton';
 export { List } from './components/data-display/List/List';
 export { Heading } from './components/typography/Heading/Heading';
+export { HeadingSkeleton } from './components/typography/Heading/HeadingSkeleton';
 export { Prose } from './components/typography/Prose/Prose';
 export { Text } from './components/typography/Text/Text';
+export { TextSkeleton } from './components/typography/Text/TextSkeleton';
 export { FormContainer } from './components/inputs/FormContainer/FormContainer';
 export { InputContainer } from './components/inputs/InputContainer/InputContainer';
 export { Select } from './components/inputs/Select/Select';
@@ -72,6 +81,7 @@ export {
   SegmentedControl as CoreSegmentedControl,
   Select as CoreSelect,
   SimpleGrid as CoreSimpleGrid,
+  Skeleton as CoreSkeleton,
   Stack as CoreStack,
   Stepper as CoreStepper,
   Switch as CoreSwitch,

--- a/apps/web/src/mantine.tsx
+++ b/apps/web/src/mantine.tsx
@@ -2,6 +2,7 @@ import {
   Combobox as MantineCombobox,
   useCombobox as useMantineCombobox,
   ActionIcon as MantineActionIcon,
+  Skeleton as MantineSkeleton,
   Alert as MantineAlert,
   Anchor as MantineAnchor,
   Badge as MantineBadge,
@@ -556,6 +557,7 @@ export const List = MantineList;
 export const Radio = MantineRadio;
 export const Stepper = MantineStepper;
 export const Popover = MantinePopover;
+export const Skeleton = MantineSkeleton;
 
 export type {
   MenuProps,


### PR DESCRIPTION
## Summary

- Adds a `Skeleton` base primitive (wraps Mantine Skeleton with our design token radius default)
- Adds companion `*Skeleton` components co-located with each DS component where a loading placeholder is meaningful:
  - `TextSkeleton` — 1–N shimmer lines sized to Text variant height; supports per-line widths
  - `HeadingSkeleton` — single line sized to heading level (h1–h6)
  - `BadgeSkeleton` — pill-radius rectangle sized to Badge sm/md
  - `PillSkeleton` — pill-radius rectangle sized to Pill sm/md/lg
  - `KPITextSkeleton` — label + value + subtext column placeholder
  - `TableSkeleton` — full table shell with configurable rows, cols, and density
  - `CardSkeleton` — Card shell with optional header, body lines, and footer buttons
  - `PageHeaderSkeleton` — title + subtitle + optional actions placeholder
- `CoreSkeleton` (raw Mantine) added to Core* exports
- All skeletons exported from `design-system/index.ts`

## Skipped (skeleton not meaningful)
Inputs, overlays, layout primitives, `Alert`, `MaterialIcon` — these are rendered on user action or are structural, not data-loaded.

## Test plan
- [ ] Import each `*Skeleton` from `design-system` and verify it renders without errors
- [ ] Confirm shimmer animation plays on each component
- [ ] Confirm `animate={false}` produces a static placeholder
- [ ] Confirm `TableSkeleton` renders correct row/col count
- [ ] Confirm `CardSkeleton` with `showFooter` renders button placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)