### PR TITLE
fix(web): show abbreviated description on all user-visible event cards

### DIFF
--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -70,7 +70,7 @@ export const LandingPage: React.FC = () => {
             {!loading && !error && activeEvents.length > 0 && (
               <Stack gap="sm">
                 {visibleActive.map((event) => (
-                  <EventCard key={event.id} event={event} description="long" now={now} />
+                  <EventCard key={event.id} event={event} description="short" now={now} />
                 ))}
                 <Inline>
                   <Link to="/events">See more events</Link>


### PR DESCRIPTION
## Summary
- All user-visible `EventCard` usages now consistently render title, metadata badges (date + registration status pills), and abbreviated (`short_description`) text
- `LandingPage` was the only callsite using `description="long"`; changed to `description="short"`
- `EventsPage`, `UserEventsPage`, and the profile `OverviewSections` were already correct

## Test plan
- [ ] Landing page event cards show short description instead of long description
- [ ] No visual regressions on Events page, User Events page, or User Profile page
- [ ] CI passes (format, lint, unit tests, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)