### PR TITLE
fix(admin): remove stage step remnants and fix challenge template editing

### DIFF
--- a/apps/api/src/modules/events/event.routes.ts
+++ b/apps/api/src/modules/events/event.routes.ts
@@ -22,6 +22,7 @@ import {
   updateEventBySlug,
   deleteEventBySlug,
   getEventDeletePreviewBySlug,
+  replaceEventGameTemplates,
 } from './event.service';
 import {
   findEligibilityForUsers,
@@ -1682,6 +1683,50 @@ router.post(
       console.error('Error creating game template:', err);
       res.status(500).json({
         error: 'Failed to create game template',
+        detail: getErrorDetail(err),
+        code: getErrorCode(err),
+      });
+    }
+  },
+);
+
+/* ------------------------------------------
+ *  PUT /api/events/:slug/game-templates  (ADMIN)
+ *  Replace all templates for a challenge event.
+ *  Fails with 409 if any games already exist.
+ * ----------------------------------------*/
+router.put(
+  '/:slug/game-templates',
+  authRequired,
+  requireAdmin,
+  async (req: AuthenticatedRequest, res: Response) => {
+    const slug = String(req.params.slug);
+    const { templates } = req.body;
+
+    if (!Array.isArray(templates)) {
+      return res.status(400).json({ error: 'templates array is required' });
+    }
+
+    for (const tpl of templates) {
+      if (tpl.template_index == null) {
+        return res.status(400).json({ error: 'Each template must have template_index' });
+      }
+    }
+
+    try {
+      const eventId = await getEventId(slug);
+      if (!eventId) return res.status(404).json({ error: 'Event not found' });
+
+      const result = await replaceEventGameTemplates(eventId, templates);
+      res.json(result);
+    } catch (err) {
+      const e = err as { code?: string };
+      if (e.code === 'TEMPLATES_HAVE_GAMES') {
+        return res.status(409).json({ error: 'Cannot replace templates: games already exist' });
+      }
+      console.error('Error replacing game templates:', err);
+      res.status(500).json({
+        error: 'Failed to replace game templates',
         detail: getErrorDetail(err),
         code: getErrorCode(err),
       });

--- a/apps/api/src/modules/events/event.service.ts
+++ b/apps/api/src/modules/events/event.service.ts
@@ -748,6 +748,81 @@ export async function createEventGameTemplate(
 }
 
 /* ------------------------------------------
+ * Replace all game templates for an event
+ * (challenge edit path — fails if games exist)
+ * ----------------------------------------*/
+export async function replaceEventGameTemplates(
+  eventId: number,
+  templates: Array<{
+    template_index: number;
+    variant?: string | null;
+    seed_payload?: string | null;
+    metadata_json?: unknown;
+  }>,
+): Promise<{ replaced: number }> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    // Fail if any games have been played against existing templates
+    const gamesCheck = await client.query<{ count: string }>(
+      `SELECT COUNT(*) AS count
+       FROM event_games g
+       JOIN event_game_templates egt ON egt.id = g.event_game_template_id
+       JOIN event_stages es ON es.event_stage_id = egt.event_stage_id
+       WHERE es.event_id = $1`,
+      [eventId],
+    );
+    if (parseInt(gamesCheck.rows[0].count, 10) > 0) {
+      throw Object.assign(new Error('Cannot replace templates: games already exist'), {
+        code: 'TEMPLATES_HAVE_GAMES',
+      });
+    }
+
+    // Delete existing templates (cascade deletes any orphaned games)
+    await client.query(
+      `DELETE FROM event_game_templates
+       WHERE event_stage_id IN (
+         SELECT event_stage_id FROM event_stages WHERE event_id = $1
+       )`,
+      [eventId],
+    );
+
+    // Get the first stage id
+    const stageResult = await client.query<{ event_stage_id: number }>(
+      `SELECT event_stage_id FROM event_stages WHERE event_id = $1 ORDER BY stage_index LIMIT 1`,
+      [eventId],
+    );
+    if (stageResult.rowCount === 0) {
+      throw new Error('No stage found for event');
+    }
+    const stageId = stageResult.rows[0].event_stage_id;
+
+    for (const tpl of templates) {
+      await client.query(
+        `INSERT INTO event_game_templates (event_stage_id, template_index, variant, seed_payload, max_score, metadata_json)
+         VALUES ($1, $2, $3, $4, 25, $5)`,
+        [
+          stageId,
+          tpl.template_index,
+          tpl.variant ?? 'No Variant',
+          tpl.seed_payload ?? null,
+          tpl.metadata_json ?? {},
+        ],
+      );
+    }
+
+    await client.query('COMMIT');
+    return { replaced: templates.length };
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* ------------------------------------------
  * List teams for an event (by event ID)
  * ----------------------------------------*/
 export async function listEventTeams(eventId: number): Promise<EventTeam[]> {

--- a/apps/web/src/pages/admin/AdminCreateEventPage.tsx
+++ b/apps/web/src/pages/admin/AdminCreateEventPage.tsx
@@ -469,13 +469,19 @@ export function AdminCreateEventPage() {
   }, [eventAbbr, eventType]);
 
   useEffect(() => {
+    if (isChallenge) return;
     const games = stages[0]?.gameCount;
     if (games != null) {
       setSeedCount(games);
     }
-  }, [stages]);
+  }, [isChallenge, stages]);
 
   useEffect(() => {
+    if (isChallenge) {
+      setStages([]);
+      return;
+    }
+
     setStages((prev) => {
       const stage0 = prev[0];
       const stage1 = prev[1];
@@ -537,7 +543,17 @@ export function AdminCreateEventPage() {
 
       return unchanged ? prev : next;
     });
-  }, [eventType, seedingPlayEnabled, seedingFormat, eventAbbr, name, startsAt, endsAt, seedCount]);
+  }, [
+    isChallenge,
+    eventType,
+    seedingPlayEnabled,
+    seedingFormat,
+    eventAbbr,
+    name,
+    startsAt,
+    endsAt,
+    seedCount,
+  ]);
 
   useEffect(() => {
     if (endsAt && !registrationCutoff) {
@@ -659,70 +675,74 @@ export function AdminCreateEventPage() {
           event.registration_cutoff ? event.registration_cutoff.slice(0, 10) : '',
         );
 
-        const loadedStages = await getJson<EventStage[]>(`/events/${editSlug}/stages`);
-        if (loadedStages.length > 0) {
-          const mapped = loadedStages.map((stage) => {
-            const config = (stage.config_json ?? {}) as {
-              stage_abbreviation?: string;
-              event_abbreviation?: string;
-              bracket_round_pattern?: {
-                name_pattern?: string;
-                abbr_pattern?: string;
-                play_days?: number;
-                gap_days?: number;
-                games_per_round?: string;
+        if (format !== 'challenge') {
+          const loadedStages = await getJson<EventStage[]>(`/events/${editSlug}/stages`);
+          if (loadedStages.length > 0) {
+            const mapped = loadedStages.map((stage) => {
+              const config = (stage.config_json ?? {}) as {
+                stage_abbreviation?: string;
+                event_abbreviation?: string;
+                bracket_round_pattern?: {
+                  name_pattern?: string;
+                  abbr_pattern?: string;
+                  play_days?: number;
+                  gap_days?: number;
+                  games_per_round?: string;
+                };
               };
+
+              const stStart = stage.starts_at ? stage.starts_at.slice(0, 10) : '';
+              const stEnd = stage.ends_at ? stage.ends_at.slice(0, 10) : '';
+              const pattern = config.bracket_round_pattern;
+
+              return {
+                id: stage.event_stage_id,
+                label: stage.label,
+                abbr: config.stage_abbreviation || config.event_abbreviation || '',
+                gameCount: seedCount,
+                startsAt: stStart,
+                endsAt: stEnd,
+                timeBound: Boolean(stStart || stEnd),
+                stageType: stage.stage_type,
+                roundPattern:
+                  stage.stage_type === 'BRACKET'
+                    ? normalizeRoundPattern({
+                        namePattern: pattern?.name_pattern,
+                        abbrPattern: pattern?.abbr_pattern,
+                        playDays: pattern?.play_days,
+                        gapDays: pattern?.gap_days,
+                        gamesPerRound: pattern?.games_per_round,
+                      })
+                    : undefined,
+              } as StageForm;
+            });
+
+            setStages(mapped.length > 0 ? mapped : [initialStage()]);
+
+            const firstConfig = (loadedStages[0]?.config_json ?? {}) as {
+              event_abbreviation?: string;
+              enforce_exact_team_size?: boolean;
             };
+            if (firstConfig.event_abbreviation) setEventAbbr(firstConfig.event_abbreviation);
 
-            const stStart = stage.starts_at ? stage.starts_at.slice(0, 10) : '';
-            const stEnd = stage.ends_at ? stage.ends_at.slice(0, 10) : '';
-            const pattern = config.bracket_round_pattern;
+            const enforce = firstConfig.enforce_exact_team_size ?? false;
 
-            return {
-              id: stage.event_stage_id,
-              label: stage.label,
-              abbr: config.stage_abbreviation || config.event_abbreviation || '',
-              gameCount: seedCount,
-              startsAt: stStart,
-              endsAt: stEnd,
-              timeBound: Boolean(stStart || stEnd),
-              stageType: stage.stage_type,
-              roundPattern:
-                stage.stage_type === 'BRACKET'
-                  ? normalizeRoundPattern({
-                      namePattern: pattern?.name_pattern,
-                      abbrPattern: pattern?.abbr_pattern,
-                      playDays: pattern?.play_days,
-                      gapDays: pattern?.gap_days,
-                      gamesPerRound: pattern?.games_per_round,
-                    })
-                  : undefined,
-            } as StageForm;
-          });
-
-          setStages(mapped.length > 0 ? mapped : [initialStage()]);
-
-          const firstConfig = (loadedStages[0]?.config_json ?? {}) as {
-            event_abbreviation?: string;
-            enforce_exact_team_size?: boolean;
-          };
-          if (firstConfig.event_abbreviation) setEventAbbr(firstConfig.event_abbreviation);
-
-          const enforce = firstConfig.enforce_exact_team_size ?? false;
-
-          setEnforceExactTeamSize(format === 'tournament' ? true : !!enforce);
+            setEnforceExactTeamSize(format === 'tournament' ? true : !!enforce);
+          }
         }
 
         const templates = await getJson<EventGameTemplate[]>(`/events/${editSlug}/game-templates`);
         if (templates.length > 0) {
           setVariant(templates[0].variant || 'No Variant');
           setSeedCount(templates.length);
-          setStages((prev) => {
-            if (prev.length === 0) return prev;
-            const next = [...prev];
-            next[0] = { ...next[0], gameCount: templates.length };
-            return next;
-          });
+          if (format !== 'challenge') {
+            setStages((prev) => {
+              if (prev.length === 0) return prev;
+              const next = [...prev];
+              next[0] = { ...next[0], gameCount: templates.length };
+              return next;
+            });
+          }
         }
 
         const badgeLinks = await listEventBadgeLinksAuth(token, editSlug);
@@ -1148,7 +1168,50 @@ export function AdminCreateEventPage() {
         }
       }
 
-      if (!isEdit && !isSessionLadder) {
+      if (!isEdit && isChallenge) {
+        const stagePayload = await postJsonAuth<{ event_stage_id: number }>(
+          `/events/${encodeURIComponent(targetSlug)}/stages`,
+          token,
+          {
+            stage_index: 1,
+            label: name,
+            stage_type: 'SINGLE',
+            starts_at: startsAt ? `${startsAt}T00:00:00Z` : null,
+            ends_at: endsAt ? `${endsAt}T23:59:59Z` : null,
+            config_json: {
+              event_abbreviation: eventAbbr || null,
+              stage_abbreviation: null,
+              enforce_exact_team_size: false,
+              bracket_type: null,
+              include_round_robin: false,
+              bracket_max_teams: null,
+              bracket_max_rounds: null,
+              seeding_play_enabled: false,
+              seeding_format: '',
+            },
+          },
+        );
+
+        const seeds = buildSeedsFromFormula(
+          seedFormula,
+          eventAbbr,
+          '',
+          'C',
+          seedCount,
+          seedHashToken,
+        );
+        for (let i = 0; i < seeds.length; i += 1) {
+          await postJsonAuth(`/events/${encodeURIComponent(targetSlug)}/game-templates`, token, {
+            event_stage_id: stagePayload.event_stage_id,
+            template_index: i + 1,
+            variant,
+            seed_payload: seeds[i],
+            metadata_json: {},
+          });
+        }
+      }
+
+      if (!isEdit && isTournament) {
         for (let idx = 0; idx < stages.length; idx += 1) {
           const stage = stages[idx];
           const stagePayload = await postJsonAuth<{ event_stage_id: number }>(
@@ -1168,8 +1231,8 @@ export function AdminCreateEventPage() {
                 include_round_robin: stage.stageType === 'ROUND_ROBIN',
                 bracket_max_teams: payloadMaxTeams,
                 bracket_max_rounds: payloadMaxRounds,
-                seeding_play_enabled: isTournament ? seedingPlayEnabled : false,
-                seeding_format: isTournament ? seedingFormat : '',
+                seeding_play_enabled: seedingPlayEnabled,
+                seeding_format: seedingFormat,
                 bracket_round_pattern:
                   stage.stageType === 'BRACKET'
                     ? {

--- a/apps/web/src/pages/admin/AdminCreateEventPage.tsx
+++ b/apps/web/src/pages/admin/AdminCreateEventPage.tsx
@@ -675,9 +675,15 @@ export function AdminCreateEventPage() {
           event.registration_cutoff ? event.registration_cutoff.slice(0, 10) : '',
         );
 
-        if (format !== 'challenge') {
-          const loadedStages = await getJson<EventStage[]>(`/events/${editSlug}/stages`);
-          if (loadedStages.length > 0) {
+        const loadedStages = await getJson<EventStage[]>(`/events/${editSlug}/stages`);
+        if (loadedStages.length > 0) {
+          const firstConfig = (loadedStages[0]?.config_json ?? {}) as {
+            event_abbreviation?: string;
+            enforce_exact_team_size?: boolean;
+          };
+          if (firstConfig.event_abbreviation) setEventAbbr(firstConfig.event_abbreviation);
+
+          if (format !== 'challenge') {
             const mapped = loadedStages.map((stage) => {
               const config = (stage.config_json ?? {}) as {
                 stage_abbreviation?: string;
@@ -718,12 +724,6 @@ export function AdminCreateEventPage() {
             });
 
             setStages(mapped.length > 0 ? mapped : [initialStage()]);
-
-            const firstConfig = (loadedStages[0]?.config_json ?? {}) as {
-              event_abbreviation?: string;
-              enforce_exact_team_size?: boolean;
-            };
-            if (firstConfig.event_abbreviation) setEventAbbr(firstConfig.event_abbreviation);
 
             const enforce = firstConfig.enforce_exact_team_size ?? false;
 
@@ -1209,6 +1209,25 @@ export function AdminCreateEventPage() {
             metadata_json: {},
           });
         }
+      }
+
+      if (isEdit && isChallenge) {
+        const seeds = buildSeedsFromFormula(
+          seedFormula,
+          eventAbbr,
+          '',
+          'C',
+          seedCount,
+          seedHashToken,
+        );
+        await putJsonAuth(`/events/${encodeURIComponent(targetSlug)}/game-templates`, token, {
+          templates: seeds.map((seed, i) => ({
+            template_index: i + 1,
+            variant,
+            seed_payload: seed,
+            metadata_json: {},
+          })),
+        });
       }
 
       if (!isEdit && isTournament) {


### PR DESCRIPTION
## Summary

- Fixes seed count being ignored when creating challenge events (stage form state was silently overriding the "Number of games" input)
- Removes all stage form state management for challenges — stages effect, seedCount sync, and edit-mode stage loading are all now skipped for challenges
- Challenge creation uses an implicit SINGLE stage built from event fields; templates are built directly from `seedCount`
- Tournament save path is now explicit and unchanged
- Adds `PUT /api/events/:slug/game-templates` endpoint to atomically replace all templates for a challenge event (returns 409 if games already exist)
- Challenge edit mode now calls this endpoint on save, so seed count and formula changes are applied to existing events

## Test plan

- [ ] Create a challenge with a non-default seed count (e.g. 42) — confirm exactly 42 templates are created
- [ ] Edit an existing challenge and change "Number of games" — confirm the template count updates on save
- [ ] Edit a challenge that already has games played — confirm save returns a 409 and templates are not replaced
- [ ] Create and edit a tournament — confirm stage step still works and templates are created per stage as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)