### PR TITLE
feat(admin): migration runner and variant sync panel in System page

### DIFF
--- a/apps/api/db/schema.sql
+++ b/apps/api/db/schema.sql
@@ -564,3 +564,18 @@ CREATE INDEX idx_admin_access_requests_requester_created
 CREATE UNIQUE INDEX uq_admin_access_requests_pending_per_user
   ON admin_access_requests (requester_user_id)
   WHERE status = 'pending';
+
+------------------------------------------------------------
+-- SCHEMA MIGRATIONS TRACKER
+------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  name TEXT PRIMARY KEY,
+  applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Mark all migrations that are already reflected in this schema as applied
+-- so the runtime migration runner skips them on fresh installs.
+INSERT INTO schema_migrations (name) VALUES
+  ('001_variant_id.sql')
+ON CONFLICT (name) DO NOTHING;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,7 @@
 import { app } from './app';
 import { env } from './config/env';
 import { info } from './utils/logger';
+import { runMigrations } from './modules/migrations/migrations.runner';
 import { startVariantSyncScheduler } from './modules/variants/variants.service';
 import { ensureNotificationsSchema } from './modules/notifications/notifications.service';
 import {
@@ -12,12 +13,16 @@ import { ensureChallengeBadgeConfigSchema } from './modules/events/event.service
 
 const server = app.listen(env.BACKEND_PORT, () => {
   info(`Backend running at http://localhost:${env.BACKEND_PORT}`);
-  startVariantSyncScheduler();
-  void Promise.all([
-    ensureNotificationsSchema(),
-    ensureAdminAccessSchema(),
-    ensureChallengeBadgeConfigSchema(),
-  ]).then(() => startNotificationDbListener());
+  void runMigrations()
+    .then(() => {
+      startVariantSyncScheduler();
+      return Promise.all([
+        ensureNotificationsSchema(),
+        ensureAdminAccessSchema(),
+        ensureChallengeBadgeConfigSchema(),
+      ]);
+    })
+    .then(() => startNotificationDbListener());
 });
 
 initNotificationsWebSocketServer(server);

--- a/apps/api/src/modules/migrations/migrations.runner.ts
+++ b/apps/api/src/modules/migrations/migrations.runner.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { pool } from '../../config/db';
+import { info, warn } from '../../utils/logger';
+
+const MIGRATIONS_DIR = path.resolve(process.cwd(), 'db/migrations');
+
+async function ensureMigrationsTable(): Promise<void> {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      name TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+}
+
+async function getAppliedMigrations(): Promise<Set<string>> {
+  const result = await pool.query<{ name: string }>(`SELECT name FROM schema_migrations`);
+  return new Set(result.rows.map((r) => r.name));
+}
+
+export async function runMigrations(): Promise<void> {
+  await ensureMigrationsTable();
+  const applied = await getAppliedMigrations();
+
+  let files: string[];
+  try {
+    files = fs
+      .readdirSync(MIGRATIONS_DIR)
+      .filter((f) => f.endsWith('.sql'))
+      .sort();
+  } catch {
+    warn(`Migrations directory not found at ${MIGRATIONS_DIR} — skipping`);
+    return;
+  }
+
+  for (const file of files) {
+    if (applied.has(file)) continue;
+
+    const filePath = path.join(MIGRATIONS_DIR, file);
+    const sql = fs.readFileSync(filePath, 'utf-8');
+
+    info(`Running migration: ${file}`);
+    const client = await pool.connect();
+    try {
+      await client.query(sql);
+      await client.query(`INSERT INTO schema_migrations (name) VALUES ($1)`, [file]);
+      info(`Migration applied: ${file}`);
+    } catch (err) {
+      warn(`Migration failed: ${file} — ${(err as Error).message}`);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/apps/web/src/features/admin/screens/AdminLayoutScreen.tsx
+++ b/apps/web/src/features/admin/screens/AdminLayoutScreen.tsx
@@ -19,7 +19,7 @@ const adminNav: AdminNavItem[] = [
   { label: 'Badges', to: '/admin/badges' },
   { label: 'Content', to: '/admin/content' },
   { label: 'Users', to: '/admin/users', superAdminOnly: true },
-  { label: 'Data Deletion', to: '/admin/data-deletion', superAdminOnly: true },
+  { label: 'System', to: '/admin/system', superAdminOnly: true },
 ];
 
 function isActivePath(currentPath: string, targetPath: string, exact = false) {

--- a/apps/web/src/features/admin/screens/system/AdminSystemHomeScreen.tsx
+++ b/apps/web/src/features/admin/screens/system/AdminSystemHomeScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   CoreGroup as Group,
   CoreStack as Stack,
@@ -12,12 +12,23 @@ import {
 } from '../../../../design-system';
 import { useAuth } from '../../../../context/AuthContext';
 import { useEvents } from '../../../../hooks/useEvents';
-import { ApiError, deleteJsonAuth, getJsonAuth } from '../../../../lib/api';
+import { ApiError, deleteJsonAuth, getJsonAuth, postJsonAuth } from '../../../../lib/api';
 import { MaterialIcon } from '../../../../design-system';
 import {
   DestructiveActionModal,
   type DestructiveConsequence,
 } from '../../../shared/modals/DestructiveActionModal';
+
+type VariantSyncResult = {
+  fetched_count: number;
+  stored_count: number;
+  synced_at: string;
+};
+
+type VariantSyncState = {
+  last_synced_at: string | null;
+  stored_count: number | null;
+};
 
 export function AdminSystemHomeScreen() {
   const { token } = useAuth();
@@ -29,6 +40,50 @@ export function AdminSystemHomeScreen() {
   } = useEvents({
     includeUnpublishedForAdmin: true,
   });
+
+  // Variant sync state
+  const [variantSync, setVariantSync] = useState<VariantSyncState>({
+    last_synced_at: null,
+    stored_count: null,
+  });
+  const [syncingVariants, setSyncingVariants] = useState(false);
+  const [syncResult, setSyncResult] = useState<VariantSyncResult | null>(null);
+  const [syncError, setSyncError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+    void getJsonAuth<{ variants: unknown[]; last_synced_at: string | null }>(
+      '/variants',
+      token,
+    ).then((data) => {
+      setVariantSync({
+        last_synced_at: data.last_synced_at,
+        stored_count: data.variants.length,
+      });
+    });
+  }, [token]);
+
+  async function triggerVariantSync() {
+    if (!token) return;
+    setSyncingVariants(true);
+    setSyncResult(null);
+    setSyncError(null);
+    try {
+      const result = await postJsonAuth<VariantSyncResult>('/variants/sync', token, {});
+      setSyncResult(result);
+      setVariantSync({ last_synced_at: result.synced_at, stored_count: result.stored_count });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const body = err.body as { error?: string } | null;
+        setSyncError(body?.error ?? `Sync failed (${err.status})`);
+      } else {
+        setSyncError('Sync failed');
+      }
+    } finally {
+      setSyncingVariants(false);
+    }
+  }
+
   const [status, setStatus] = useState<{ ok: boolean; message: string } | null>(null);
   const [modalError, setModalError] = useState<string | null>(null);
   const [loadingPreview, setLoadingPreview] = useState(false);
@@ -139,6 +194,53 @@ export function AdminSystemHomeScreen() {
 
   return (
     <Stack gap="md">
+      <Title order={3}>Variant Catalog</Title>
+
+      <SectionCard>
+        <Stack gap="sm">
+          <Text fw={700}>Hanabi variant sync</Text>
+          <Text size="sm" c="dimmed">
+            Syncs the variant catalog from the hanab.live repository. Runs automatically on startup
+            and weekly thereafter.
+          </Text>
+          <Group align="center" gap="sm">
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={syncingVariants}
+              onClick={() => void triggerVariantSync()}
+            >
+              {syncingVariants ? 'Syncing…' : 'Sync now'}
+            </Button>
+            {variantSync.last_synced_at && (
+              <Text size="sm" c="dimmed">
+                Last synced:{' '}
+                {new Date(variantSync.last_synced_at).toLocaleString(undefined, {
+                  dateStyle: 'medium',
+                  timeStyle: 'short',
+                })}
+                {variantSync.stored_count !== null && ` · ${variantSync.stored_count} variants`}
+              </Text>
+            )}
+            {!variantSync.last_synced_at && variantSync.stored_count === null && (
+              <Text size="sm" c="dimmed">
+                Never synced
+              </Text>
+            )}
+          </Group>
+          {syncResult && (
+            <Text size="sm" c="green">
+              Sync complete — {syncResult.fetched_count} fetched, {syncResult.stored_count} stored.
+            </Text>
+          )}
+          {syncError && (
+            <Text size="sm" c="red">
+              {syncError}
+            </Text>
+          )}
+        </Stack>
+      </SectionCard>
+
       <Title order={3}>Data Deletion</Title>
 
       <SectionCard>

--- a/apps/web/src/features/admin/screens/system/AdminSystemLayoutScreen.tsx
+++ b/apps/web/src/features/admin/screens/system/AdminSystemLayoutScreen.tsx
@@ -5,8 +5,8 @@ export function AdminSystemLayoutScreen() {
   return (
     <Box component="section">
       <PageHeader
-        title="Data Deletion"
-        subtitle="Destructive maintenance tools for event data."
+        title="System"
+        subtitle="Variant catalog, data maintenance, and other superadmin tools."
         level={2}
       />
       <Divider my="md" />

--- a/apps/web/src/routes/AppRoutes.tsx
+++ b/apps/web/src/routes/AppRoutes.tsx
@@ -85,7 +85,7 @@ function AdminRoutes() {
       </Route>
 
       <Route
-        path="data-deletion"
+        path="system"
         element={
           <RequireSuperAdmin>
             <AdminSystemLayoutScreen />
@@ -97,7 +97,7 @@ function AdminRoutes() {
 
       <Route path="create-event" element={<Navigate to="/admin/events/create" replace />} />
       <Route path="manage-users" element={<Navigate to="/admin/users" replace />} />
-      <Route path="system" element={<Navigate to="/admin/data-deletion" replace />} />
+      <Route path="data-deletion" element={<Navigate to="/admin/system" replace />} />
     </Route>
   );
 }


### PR DESCRIPTION
## Summary

- **Migration runner**: new `migrations.runner.ts` reads `db/migrations/*.sql` at API startup in sorted order, tracks applied migrations in a `schema_migrations` table, and skips already-applied files. Runs before variant sync and `ensure*` schema calls.
- **Fresh-install safety**: `schema.sql` now creates `schema_migrations` and pre-seeds `001_variant_id.sql` as already applied, so a clean DB install never re-runs the migration.
- **Admin System page**: the "Data Deletion" tab is renamed to "System" (route `/admin/system`; `/admin/data-deletion` redirects). The page now has a **Variant Catalog** section at the top with last-synced timestamp, variant count, and a "Sync now" button (`POST /api/variants/sync`).

## Test plan

- [ ] Start the API against an existing DB that has `variant TEXT` (pre-migration) — confirm `001_variant_id.sql` runs automatically on startup and the column is migrated
- [ ] Start the API against a fresh DB (schema.sql applied) — confirm migration is skipped (already in `schema_migrations`)
- [ ] Navigate to `/admin/system` as a superadmin — confirm "Variant Catalog" section appears, last synced time is shown, "Sync now" triggers a sync and updates the counts
- [ ] Navigate to `/admin/data-deletion` — confirm redirect to `/admin/system`
- [ ] Confirm data deletion tools still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)