### PR TITLE
fix(migrations): make 001_variant_id self-contained; surface errors

### DIFF
--- a/apps/api/db/migrations/001_variant_id.sql
+++ b/apps/api/db/migrations/001_variant_id.sql
@@ -1,11 +1,21 @@
 -- Migration 001: store variant as numeric ID instead of string name
 --
 -- event_game_templates.variant (TEXT) → variant_id (INTEGER FK → hanabi_variants.code)
--- The hanabi_variants catalog must be populated before this migration runs.
--- Any template whose variant name has no matching entry in hanabi_variants
--- defaults to 0 (No Variant).
+-- Self-contained: seeds the No Variant catalog row so the FK default always resolves.
 
 BEGIN;
+
+-- Ensure hanabi_variants exists and has the No Variant fallback row
+CREATE TABLE IF NOT EXISTS hanabi_variants (
+  code INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  label TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO hanabi_variants (code, name, label)
+VALUES (0, 'No Variant', 'No Variant')
+ON CONFLICT (code) DO NOTHING;
 
 -- 1. Add new integer column (nullable for now so existing rows are accepted)
 ALTER TABLE event_game_templates

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
 import { app } from './app';
 import { env } from './config/env';
-import { info } from './utils/logger';
+import { info, warn } from './utils/logger';
 import { runMigrations } from './modules/migrations/migrations.runner';
 import { startVariantSyncScheduler } from './modules/variants/variants.service';
 import { ensureNotificationsSchema } from './modules/notifications/notifications.service';
@@ -13,7 +13,7 @@ import { ensureChallengeBadgeConfigSchema } from './modules/events/event.service
 
 const server = app.listen(env.BACKEND_PORT, () => {
   info(`Backend running at http://localhost:${env.BACKEND_PORT}`);
-  void runMigrations()
+  runMigrations()
     .then(() => {
       startVariantSyncScheduler();
       return Promise.all([
@@ -22,7 +22,10 @@ const server = app.listen(env.BACKEND_PORT, () => {
         ensureChallengeBadgeConfigSchema(),
       ]);
     })
-    .then(() => startNotificationDbListener());
+    .then(() => startNotificationDbListener())
+    .catch((err: unknown) => {
+      warn('Startup sequence failed:', err);
+    });
 });
 
 initNotificationsWebSocketServer(server);


### PR DESCRIPTION
## Summary

Hotfix for the "Failed to load team" regression introduced when PR #50 was deployed without the migration having run.

**Root cause**: `001_variant_id.sql` assumes `hanabi_variants` has a `code=0` row for the fallback `UPDATE SET variant_id=0`. On production the table was empty (never synced), causing an FK violation. The transaction rolled back silently (errors were swallowed via `void`), so the server started with the old `variant TEXT` column still in place — making every team page 500.

**Changes:**
- Migration now creates `hanabi_variants` itself and seeds `code=0` before any FK-dependent operations, so it is fully self-contained regardless of sync state
- `index.ts`: replaced `void` swallow with `.catch()` so migration failures are logged via `warn()` rather than silently dropped

## Test plan

- [ ] Deploy to a DB that has never had a variant sync — confirm migration runs successfully on restart and team pages load
- [ ] Confirm `schema_migrations` table shows `001_variant_id.sql` as applied after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)