### PR TITLE
fix(render): initialize git submodule before build

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -53,7 +53,7 @@ services:
       - key: JWT_SECRET
         sync: false
       # SIMULATION_MODE intentionally absent — defaults to false
-    buildCommand: COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
+    buildCommand: git submodule update --init --recursive && COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
     startCommand: node apps/api/dist/src/scripts/bootstrap-db.js && node apps/api/dist/src/index.js
     healthCheckPath: /health
     domains:
@@ -122,7 +122,7 @@ services:
         generateValue: true
       - key: SIMULATION_MODE
         value: true
-    buildCommand: COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
+    buildCommand: git submodule update --init --recursive && COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
     startCommand: node apps/api/dist/src/scripts/bootstrap-db.js && node apps/api/dist/src/index.js
     healthCheckPath: /health
 


### PR DESCRIPTION
## Summary
- `vendor/hanabi-live` is a git submodule that Render does not initialize automatically
- This caused the `@hanabi-live/game` package to be missing on Render, failing the TypeScript build with `Cannot find module '@hanabi-live/game'`
- Prepends `git submodule update --init --recursive` to the API build command

## Test plan
- [ ] Verify prod API redeploys successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)