### PR TITLE
fix(render): build @hanabi-live/game dist before pnpm install

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -53,7 +53,7 @@ services:
       - key: JWT_SECRET
         sync: false
       # SIMULATION_MODE intentionally absent — defaults to false
-    buildCommand: git submodule update --init --recursive && COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
+    buildCommand: git submodule update --init --recursive && npm --prefix vendor/hanabi-live/packages/game install && npm --prefix vendor/hanabi-live/packages/game run build && COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
     startCommand: node apps/api/dist/src/scripts/bootstrap-db.js && node apps/api/dist/src/index.js
     healthCheckPath: /health
     domains:
@@ -122,7 +122,7 @@ services:
         generateValue: true
       - key: SIMULATION_MODE
         value: true
-    buildCommand: git submodule update --init --recursive && COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
+    buildCommand: git submodule update --init --recursive && npm --prefix vendor/hanabi-live/packages/game install && npm --prefix vendor/hanabi-live/packages/game run build && COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/api... && pnpm -C apps/api run build
     startCommand: node apps/api/dist/src/scripts/bootstrap-db.js && node apps/api/dist/src/index.js
     healthCheckPath: /health
 


### PR DESCRIPTION
## Summary
- The `vendor/hanabi-live` submodule's `dist/` is not committed to git — it exists locally but is built from source
- After the submodule is cloned on Render, there is no `dist/`, so pnpm cannot resolve `@hanabi-live/game` and the TypeScript build fails
- Adds `npm install` + `npm run build` in `vendor/hanabi-live/packages/game/` between submodule init and the pnpm workspace install, for both API services

## Test plan
- [ ] Verify prod and test API builds succeed on Render after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)