### PR TITLE
fix(api): include src/scripts in TypeScript build

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -14,5 +14,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "vitest*.ts"],
-  "exclude": ["dist", "node_modules", "src/scripts"]
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- `src/scripts` was excluded from `tsconfig.json`, so `tsc` never compiled `bootstrap-db.js` and other scripts
- On Render's fresh build environment there is no pre-existing `dist/`, so the start command `node apps/api/dist/src/scripts/bootstrap-db.js` failed with `Cannot find module`
- Removes `src/scripts` from the `exclude` list so scripts are compiled alongside the rest of the API

## Test plan
- [ ] Verify Render API starts successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)