### PR TITLE
fix(bootstrap-db): backfill schema_migrations on every startup

### DIFF
--- a/apps/api/src/scripts/bootstrap-db.ts
+++ b/apps/api/src/scripts/bootstrap-db.ts
@@ -9,6 +9,35 @@ function resolveSchemaPath(): string {
   return process.cwd().endsWith(path.join('apps', 'api')) ? fromApiDir : fromRepoRoot;
 }
 
+async function backfillSchemaMigrations(pool: Pool, schemaPath: string): Promise<void> {
+  const migrationsDir = path.join(path.dirname(schemaPath), 'migrations');
+  let migrationFiles: string[];
+  try {
+    const entries = await fs.readdir(migrationsDir);
+    migrationFiles = entries.filter((f) => f.endsWith('.sql')).sort();
+  } catch {
+    console.log('[db-bootstrap] Migrations directory not accessible; skipping backfill.');
+    return;
+  }
+  if (migrationFiles.length === 0) return;
+
+  const inserts = migrationFiles
+    .map(
+      (f) => `INSERT INTO schema_migrations (name) VALUES ('${f}') ON CONFLICT (name) DO NOTHING;`,
+    )
+    .join('\n  ');
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      name TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+    ${inserts}
+  `);
+  console.log(
+    `[db-bootstrap] Backfilled schema_migrations with ${migrationFiles.length} baseline entries.`,
+  );
+}
+
 async function main(): Promise<void> {
   const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
@@ -34,12 +63,16 @@ async function main(): Promise<void> {
 
     if (usersTable) {
       console.log('[db-bootstrap] Existing schema detected; skipping initialization.');
-      return;
+    } else {
+      console.log('[db-bootstrap] No users table found. Applying apps/api/db/schema.sql...');
+      await pool.query(schemaSql);
+      console.log('[db-bootstrap] Schema initialization complete.');
     }
 
-    console.log('[db-bootstrap] No users table found. Applying apps/api/db/schema.sql...');
-    await pool.query(schemaSql);
-    console.log('[db-bootstrap] Schema initialization complete.');
+    // Always backfill schema_migrations so that databases initialized with older schema.sql
+    // (which may not have seeded the full migration list) never re-apply already-reflected
+    // migrations (e.g. migration 002 which drops tables without CASCADE).
+    await backfillSchemaMigrations(pool, schemaPath);
   } finally {
     await pool.end();
   }


### PR DESCRIPTION
## Summary

- Databases initialized with an older `schema.sql` (that didn't seed the full migration list) could have migration 002 treated as unapplied by the runner
- Migration 002 does `DROP TABLE IF EXISTS events;` **without CASCADE**, which fails on any DB that already has the new schema (event_stages, event_admins, etc. still reference events)
- Fix: `bootstrap-db` now always runs an idempotent `INSERT INTO schema_migrations ... ON CONFLICT DO NOTHING` for every `.sql` file found in `db/migrations/`, whether or not the full schema init was skipped

## Test plan

- [ ] Render preview environment deploys without the "cannot drop table events" startup error
- [ ] Existing test databases with users table boot normally (bootstrap skips schema init, backfills migrations, app starts)
- [ ] Fresh databases still initialize correctly (schema.sql seeds migrations, backfill is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)