### PR TITLE
fix(bootstrap-db): only backfill when new event model schema is present

### DIFF
--- a/apps/api/src/scripts/bootstrap-db.ts
+++ b/apps/api/src/scripts/bootstrap-db.ts
@@ -69,10 +69,28 @@ async function main(): Promise<void> {
       console.log('[db-bootstrap] Schema initialization complete.');
     }
 
-    // Always backfill schema_migrations so that databases initialized with older schema.sql
-    // (which may not have seeded the full migration list) never re-apply already-reflected
-    // migrations (e.g. migration 002 which drops tables without CASCADE).
-    await backfillSchemaMigrations(pool, schemaPath);
+    // Backfill schema_migrations only when the DB already has the new event model schema
+    // (event_stages.time_policy is the sentinel column introduced by migration 002).
+    //
+    // This prevents incorrectly marking migrations as applied on databases that still have
+    // the pre-migration-002 schema and actually need those migrations to run.  For databases
+    // that already have the new schema (but whose schema_migrations may be missing entries
+    // because an older schema.sql didn't seed them), the backfill prevents the migration
+    // runner from re-applying migration 002, which drops tables without CASCADE and would
+    // otherwise fail against the new schema.
+    const schemaVersionCheck = await pool.query<{ exists: boolean }>(`
+      SELECT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'event_stages' AND column_name = 'time_policy'
+      ) AS exists
+    `);
+    if (schemaVersionCheck.rows[0]?.exists) {
+      await backfillSchemaMigrations(pool, schemaPath);
+    } else {
+      console.log(
+        '[db-bootstrap] Pre-migration-002 schema detected; skipping backfill — migration runner will apply outstanding migrations.',
+      );
+    }
   } finally {
     await pool.end();
   }


### PR DESCRIPTION
## Summary

- The previous fix (#60) unconditionally backfilled `schema_migrations` with all 30 migrations — including on databases that still have the **pre-migration-002 schema** (old session model, no `event_stages.time_policy` column)
- On those databases, migration 002 was skipped by the runner, leaving `event_stages` without `time_policy`/`starts_at`/`ends_at`/`stage_index` — the columns `GET /api/events` requires — causing a 500 on every events request
- Fix: gate the backfill on whether `event_stages.time_policy` exists (the sentinel column added by migration 002). Pre-migration-002 databases skip the backfill and let the migration runner apply outstanding migrations normally

## Decision table

| DB state | `event_stages.time_policy` | Backfill? | Result |
|---|---|---|---|
| Fresh install (schema.sql just ran) | ✓ exists | Yes (no-op) | ✓ works |
| New schema, old schema_migrations seeding | ✓ exists | Yes (prevents 002 re-run) | ✓ works |
| Pre-migration-002 schema | ✗ missing | No | Migration runner applies 002+ normally |

## Test plan

- [ ] Fresh preview DB boots, GET /api/events returns `[]`
- [ ] Permanent test DB with pre-migration-002 schema runs migrations and GET /api/events succeeds
- [ ] Permanent test DB with new schema but stale schema_migrations still skips migration 002

🤖 Generated with [Claude Code](https://claude.com/claude-code)