### PR TITLE
docs(tracker): publishing conventions and architecture (#000)

### DIFF
--- a/tracker/ARCHITECTURE.md
+++ b/tracker/ARCHITECTURE.md
@@ -1,0 +1,202 @@
+# Tracker — Architecture
+
+## Overview
+
+The tracker is a distinct package within the Hanabi Competitions monorepo. It shares the repo's existing toolchain, CI, and design system but is architecturally isolated: it has its own routes, database schema, build outputs, and deployment concerns.
+
+```
+hanabi-challenges/
+├── apps/api/           ← existing site API (unchanged)
+├── apps/web/           ← existing site frontend (unchanged)
+├── packages/shared/    ← existing shared types
+└── tracker/
+    ├── server/         ← Express routes, DB queries, services (Node.js)
+    ├── client/         ← React frontend mounted at /tracker (Vite)
+    ├── types/          ← shared data contracts (imported by both)
+    ├── ARCHITECTURE.md ← this file
+    ├── PUBLISHING.md   ← publishing and branch procedures
+    └── README.md       ← setup and development guide
+```
+
+---
+
+## Package Structure
+
+### `tracker/types`
+
+The **source of truth for all request and response shapes**. Both `tracker/server` and `tracker/client` import from `@tracker/types` — neither defines its own independently. If the shape of an API request or response changes, the change happens here first.
+
+### `tracker/server`
+
+The backend package. Contains:
+
+- `src/routes/` — Express router definitions; one file per resource
+- `src/db/` — typed async query functions; one file per domain; no ORM
+- `src/services/` — business logic (lifecycle engine, notification service, Discord dispatcher, GitHub integration)
+- `src/middleware/` — auth, role resolution, permission enforcement, error handling
+- `src/migrations/` — timestamped SQL migration files (`YYYYMMDDHHMMSS_description.sql`)
+- `src/bot/` — Discord bot entry point (separate process from the Express server)
+
+### `tracker/client`
+
+The frontend package. Built with Vite. Uses the existing site's design system directly — no new design system is introduced, no components are duplicated.
+
+---
+
+## Non-Negotiable Invariants
+
+The following rules are absolute. They are enforced by code review; any PR that violates them must not be merged.
+
+### 1. The Lifecycle Engine Owns Status History
+
+The lifecycle engine (`src/services/lifecycle.ts`) is the **only** code path that:
+- Writes to `ticket_status_history`
+- Updates `current_status_id` on a ticket
+
+No route handler, service, or utility may write to these tables directly. Violations undermine the integrity of the audit trail and the valid-transitions enforcement.
+
+### 2. Parameterised Queries Everywhere
+
+All database queries use parameterised inputs. **No string interpolation of user data anywhere.** If a query contains a template literal with a user-supplied value, it is a bug and must not be merged.
+
+### 3. Types Package Is the Single Source of Truth
+
+Server and client both import request/response shapes from `@tracker/types`. Neither defines its own independently. A type that lives in only one package is a type that will eventually drift.
+
+### 4. The Discord Bot Is a Separate Process
+
+The Discord bot (`tracker/server/src/bot/index.ts`) has its own entry point and runs as a separate long-lived process. It is not part of the Express server. The two communicate only via the database — the bot writes to `discord_role_sync_log`; the server reads from it.
+
+### 5. Dormant-Until-Go-Live Integrations
+
+The Discord outbound webhook and the Discord bot are dormant until go-live, controlled purely by the **presence or absence of their respective environment variables**:
+
+- No `DISCORD_MOD_WEBHOOK_URL` → outbound webhook does nothing
+- No `DISCORD_BOT_TOKEN` / `DISCORD_GUILD_ID` / `DISCORD_MOD_ROLE_NAME` → bot process does not start
+
+No code changes are required at go-live. Setting the environment variables and redeploying is sufficient.
+
+### 6. hanab.live Is the Authoritative Identity Source
+
+The tracker **never creates or manages identities independently**. It only maps hanab.live usernames to local user records. The sequence is always:
+
+1. User authenticates with the existing site (which authenticates via hanab.live)
+2. Tracker middleware reads the resolved hanab.live username from the existing session
+3. Tracker performs a lookup/upsert on `users.hanablive_username`
+
+The tracker user record is a derived artefact — the hanab.live username is the ground truth.
+
+### 7. Timestamp-Based Migration Filenames
+
+Migration files are named `YYYYMMDDHHMMSS_description.sql` (e.g. `20240315120000_create_tickets.sql`). **Sequential numbers are never used.** This prevents merge conflicts when tracker and main-site migrations are developed in parallel.
+
+---
+
+## Database Strategy
+
+The tracker uses its own schema (`tracker`) within the same PostgreSQL instance as the existing site. This means:
+
+- The tracker's tables are completely separate from the existing site's tables
+- A single database instance to manage in production
+- The tracker's migration tracking table is named `tracker_schema_migrations` to avoid collision with the existing site's `schema_migrations`
+- All tracker table names are unambiguously scoped (either prefixed or in the `tracker` schema)
+
+The query client is `postgres.js` (`postgres` on npm). No ORM. All queries are typed async functions in `tracker/server/src/db/`, one file per domain.
+
+---
+
+## Authentication Architecture
+
+The tracker does not own authentication. The flow is:
+
+1. The existing site authenticates users via hanab.live and establishes a session
+2. The tracker's `requireTrackerAuth` middleware reads the hanab.live username from the existing session (via `req.user` or equivalent — see `tracker/README.md` for the exact mechanism)
+3. The tracker does a lookup/upsert on `tracker.users` by `hanablive_username`, creating a tracker record on first access and syncing `display_name` if it has changed
+4. The resolved tracker user is attached to `req.trackerUser` (namespaced to avoid collision with any existing `req.user`)
+
+Unauthenticated requests to protected tracker routes return HTTP 401 before reaching any route handler.
+
+---
+
+## Permission Model
+
+Permissions are enforced at the route level via the `requirePermission(action)` middleware factory:
+
+```
+requirePermission('ticket.create')  → passes if req.trackerRole has ticket.create
+requirePermission('ticket.triage')  → passes for moderator and committee, fails for community_member
+```
+
+The role is resolved once per request in the `resolveTrackerRole` middleware and attached to `req.trackerRole`. It defaults to `community_member` if no elevated assignment is active. Users with `account_status = 'banned'` or `'restricted'` are rejected with 403 before role resolution.
+
+Permission data lives in the `tracker.permissions` table (seeded at migration time, not user-configurable).
+
+---
+
+## Error Response Shape
+
+All tracker error responses share this shape:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Human-readable description",
+    "correlationId": "uuid-v4"
+  }
+}
+```
+
+Standard codes:
+- `VALIDATION_ERROR` (422) — request body failed schema validation
+- `UNAUTHORIZED` (401) — no valid session
+- `FORBIDDEN` (403) — authenticated but insufficient permission
+- `NOT_FOUND` (404) — resource does not exist
+- `CONFLICT` (409) — e.g. duplicate vote, duplicate identity link
+- `INTERNAL_ERROR` (500) — unhandled server error (no detail exposed to client)
+
+---
+
+## Logging
+
+Structured JSON logging via `pino`. Every tracker request produces a log line with: method, path, status code, duration (ms), and correlation id. Correlation ids are assigned at the tracker middleware boundary (UUID per request) and included in all downstream log output for that request.
+
+Log level is configurable via `TRACKER_LOG_LEVEL` environment variable (default: `info`).
+
+User data is never logged. Only user UUIDs appear in log output — never usernames, display names, or email addresses.
+
+HTTP 500 errors log the full stack trace server-side; the client receives only the correlation id and a generic message.
+
+---
+
+## Notification Fanout
+
+Notification fanout is synchronous at this community scale. When a lifecycle event occurs:
+
+1. A `notification_events` row is inserted
+2. The notification service queries `ticket_subscriptions` for all subscribed users
+3. `user_notifications` rows are inserted for each subscriber (excluding the actor)
+4. The Discord outbound webhook fires (fire-and-forget, after transaction commit)
+
+There is no queue. If the process crashes between the transaction commit and the Discord dispatch, the Discord message is lost. This is acceptable at this scale — the audit trail in `ticket_status_history` is always consistent.
+
+---
+
+## Discord Integration Architecture
+
+Two separate Discord integration components:
+
+### Outbound Webhook (server-side, dormant until go-live)
+
+Fires after significant lifecycle events (ticket submitted, status changed). Sends a structured message to the configured mod channel webhook URL. Entirely fire-and-forget — delivery failures are logged to `discord_delivery_log` but do not affect the response to the user or the integrity of the ticket lifecycle.
+
+Activated by setting `DISCORD_MOD_WEBHOOK_URL`.
+
+### Inbound Bot (separate process, dormant until go-live)
+
+A long-lived Discord bot process (`tracker/server/src/bot/index.ts`) that:
+- Listens for role changes in the guild and writes to `discord_role_sync_log`
+- Exposes a `/token` slash command that links a Discord identity to a hanab.live username
+- On successful `/token`: applies any pending role grants from `discord_role_sync_log`
+
+Activated by setting `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`, and `DISCORD_MOD_ROLE_NAME`, then redeploying.

--- a/tracker/PUBLISHING.md
+++ b/tracker/PUBLISHING.md
@@ -6,18 +6,18 @@ All tracker work follows a two-tier branch structure:
 
 ```
 main
-  └── tracker                    ← long-lived; never merges to main until the project is complete
-        ├── tracker/ticket-001   ← per-ticket branch; merges into tracker when green
+  └── tracker-main               ← long-lived; never merges to main until the project is complete
+        ├── tracker/ticket-001   ← per-ticket branch; merges into tracker-main when green
         ├── tracker/ticket-002
         └── ...
 ```
 
-- **`tracker`** is the long-lived integration branch. It represents all completed, passing tracker work at any given moment. It is never merged into `main` until every ticket is done and the full E2E suite is green.
-- **Per-ticket branches** are named `tracker/ticket-NNN` (e.g. `tracker/ticket-015`). They branch off `tracker` and merge back into `tracker` when complete.
-- Direct pushes to `tracker` are blocked — all changes arrive via PR from a per-ticket branch.
-- Work is strictly sequential. A new per-ticket branch is never started until the previous ticket's PR has been merged into `tracker` with green CI.
+- **`tracker-main`** is the long-lived integration branch. It represents all completed, passing tracker work at any given moment. It is never merged into `main` until every ticket is done and the full E2E suite is green.
+- **Per-ticket branches** are named `tracker/ticket-NNN` (e.g. `tracker/ticket-015`). They branch off `tracker-main` and merge back into `tracker-main` when complete.
+- Direct pushes to `tracker-main` are blocked — all changes arrive via PR from a per-ticket branch.
+- Work is strictly sequential. A new per-ticket branch is never started until the previous ticket's PR has been merged into `tracker-main` with green CI.
 
-> **Git namespace note:** Because git cannot hold both a branch named `tracker` and branches named `tracker/*` as local refs simultaneously, delete the local `tracker` branch after pushing it to the remote. All per-ticket work is done on `tracker/ticket-NNN` branches that track `origin/tracker`. Merges to `origin/tracker` are done via GitHub PR; no local `tracker` branch is required.
+> **Git namespace note:** The spec originally called the integration branch `tracker`. Git cannot hold both a branch named `tracker` and branches named `tracker/*` simultaneously (git would need `tracker` to be both a file and a directory in `.git/refs/heads/`). The integration branch was therefore named `tracker-main` to preserve the `tracker/*` namespace for per-ticket branches. This is a permanent design decision — do not attempt to rename it back.
 
 ---
 
@@ -66,7 +66,7 @@ This is an absolute rule with no exceptions:
 1. CI must be green on the per-ticket branch before a PR can be opened
 2. CI must be green on the PR before it can be merged into `tracker`
 3. A new per-ticket branch is never started while CI is red on any open PR
-4. If CI breaks on `tracker` itself, all other work stops until it is fixed
+4. If CI breaks on `tracker-main` itself, all other work stops until it is fixed
 
 If CI is failing, that is the only work. There is no parallel progress.
 
@@ -102,19 +102,19 @@ Before promoting any build to production, verify the following on staging:
 
 All of the following must be true before promoting to production:
 
-- [ ] All CI jobs green on the `tracker` branch
+- [ ] All CI jobs green on the `tracker-main` branch
 - [ ] Staging verification checklist complete
 - [ ] `tracker/SECURITY_REVIEW.md` complete with no unresolved findings
 - [ ] `tracker/QUERY_REVIEW.md` complete with no unresolved performance concerns
 - [ ] All environment variables confirmed provisioned in production
 - [ ] Rollback procedure tested on staging within the last 7 days
-- [ ] The final `tracker` to `main` PR has been reviewed
+- [ ] The final `tracker-main` to `main` PR has been reviewed
 
 ---
 
 ## The Final Merge to Main
 
-When all 48 tickets are complete and the `tracker` branch is fully green including the E2E suite, one PR is opened from `tracker` into `main`. That PR's description serves as the release notes: what the tracker is, what it does, and the go-live checklist. The final merge to `main` is the only moment the tracker becomes part of the production codebase.
+When all 48 tickets are complete and the `tracker-main` branch is fully green including the E2E suite, one PR is opened from `tracker-main` into `main`. That PR's description serves as the release notes: what the tracker is, what it does, and the go-live checklist. The final merge to `main` is the only moment the tracker becomes part of the production codebase.
 
 ---
 

--- a/tracker/PUBLISHING.md
+++ b/tracker/PUBLISHING.md
@@ -1,0 +1,166 @@
+# Tracker — Publishing Procedures
+
+## Branch Strategy
+
+All tracker work follows a two-tier branch structure:
+
+```
+main
+  └── tracker                    ← long-lived; never merges to main until the project is complete
+        ├── tracker/ticket-001   ← per-ticket branch; merges into tracker when green
+        ├── tracker/ticket-002
+        └── ...
+```
+
+- **`tracker`** is the long-lived integration branch. It represents all completed, passing tracker work at any given moment. It is never merged into `main` until every ticket is done and the full E2E suite is green.
+- **Per-ticket branches** are named `tracker/ticket-NNN` (e.g. `tracker/ticket-015`). They branch off `tracker` and merge back into `tracker` when complete.
+- Direct pushes to `tracker` are blocked — all changes arrive via PR from a per-ticket branch.
+- Work is strictly sequential. A new per-ticket branch is never started until the previous ticket's PR has been merged into `tracker` with green CI.
+
+> **Git namespace note:** Because git cannot hold both a branch named `tracker` and branches named `tracker/*` as local refs simultaneously, delete the local `tracker` branch after pushing it to the remote. All per-ticket work is done on `tracker/ticket-NNN` branches that track `origin/tracker`. Merges to `origin/tracker` are done via GitHub PR; no local `tracker` branch is required.
+
+---
+
+## Commit Conventions
+
+All commits follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. Types used in this project:
+
+| Type        | Purpose                                                    |
+| ----------- | ---------------------------------------------------------- |
+| `feat`      | New functionality                                          |
+| `fix`       | A bug fix                                                  |
+| `chore`     | Tooling, configuration, scaffolding with no production code change |
+| `test`      | Test additions or modifications                            |
+| `docs`      | Documentation changes only                                 |
+| `refactor`  | Code restructuring without behaviour change                |
+| `perf`      | Performance improvements                                   |
+| `ci`        | CI pipeline changes                                        |
+| `migration` | Database migration additions                               |
+
+**Scope** is optional but encouraged where it adds clarity: `feat(tickets):`, `feat(discord):`, `fix(lifecycle):`, `migration(users):`.
+
+**Subject line rules:** imperative mood ("add vote endpoint" not "added vote endpoint"), under 72 characters, no trailing period.
+
+**Body and footer:** used when context is needed — explain *why*, not *what*. Document any design decision made during implementation that deviated from the spec, any constraint discovered that future tickets should know about, and any migration that requires special handling on deploy.
+
+---
+
+## Merge Policy
+
+When merging a per-ticket branch into `tracker`, use **squash merge** — one commit per ticket on the `tracker` branch. The squash commit message follows this format:
+
+```
+type(scope): description (#NNN)
+```
+
+Example: `feat(tickets): implement ticket creation endpoint (#015)`
+
+The full commit history is preserved on the per-ticket branch. The `tracker` branch stays clean and readable.
+
+---
+
+## The "Never Progress Until Green" Rule
+
+This is an absolute rule with no exceptions:
+
+1. CI must be green on the per-ticket branch before a PR can be opened
+2. CI must be green on the PR before it can be merged into `tracker`
+3. A new per-ticket branch is never started while CI is red on any open PR
+4. If CI breaks on `tracker` itself, all other work stops until it is fixed
+
+If CI is failing, that is the only work. There is no parallel progress.
+
+---
+
+## PR Requirements
+
+Every PR from a per-ticket branch into `tracker` must include:
+
+- **Summary**: one paragraph describing what this ticket implements in plain English
+- **Design decisions**: any decisions made during implementation that deviated from the spec or required judgment not captured in the ticket — this is the permanent record of *why* things were built a certain way
+- **Verification steps**: the specific commands or manual steps needed to verify the work locally
+- **Test coverage**: what the tests cover and, honestly, what they do not
+- **Follow-on notes**: anything the next ticket needs to know — constraints discovered, assumptions made, technical debt incurred
+
+---
+
+## Staging Verification Checklist
+
+Before promoting any build to production, verify the following on staging:
+
+- [ ] All CI jobs green on the `tracker` branch
+- [ ] `GET /tracker/health` and `GET /tracker/health/db` return 200
+- [ ] A ticket can be submitted end-to-end by a community member account
+- [ ] A ticket can be triaged by a moderator account
+- [ ] A committee member can make a decision with a resolution note
+- [ ] The Discord outbound webhook delivers a message to the mod channel (requires staging Discord configuration)
+- [ ] The Discord `/token` command successfully links an identity on staging
+
+---
+
+## Go/No-Go Criteria for Production Promotion
+
+All of the following must be true before promoting to production:
+
+- [ ] All CI jobs green on the `tracker` branch
+- [ ] Staging verification checklist complete
+- [ ] `tracker/SECURITY_REVIEW.md` complete with no unresolved findings
+- [ ] `tracker/QUERY_REVIEW.md` complete with no unresolved performance concerns
+- [ ] All environment variables confirmed provisioned in production
+- [ ] Rollback procedure tested on staging within the last 7 days
+- [ ] The final `tracker` to `main` PR has been reviewed
+
+---
+
+## The Final Merge to Main
+
+When all 48 tickets are complete and the `tracker` branch is fully green including the E2E suite, one PR is opened from `tracker` into `main`. That PR's description serves as the release notes: what the tracker is, what it does, and the go-live checklist. The final merge to `main` is the only moment the tracker becomes part of the production codebase.
+
+---
+
+## Go-Live Activation for Dormant Integrations
+
+These steps require no deployment — configuration only:
+
+- **Discord outbound webhook**: set `DISCORD_MOD_WEBHOOK_URL` in the production environment. The dispatcher activates on the next ticket submission.
+- **Discord bot**: set `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`, and `DISCORD_MOD_ROLE_NAME` in the production environment, then redeploy so the bot process starts. Verify by running `/token` in the Discord server.
+
+---
+
+## Migration Safety Requirements
+
+Every database migration must be backwards-compatible with the previous deployed server version:
+
+- New columns must have defaults or be nullable
+- No column may be dropped or renamed in the same migration that introduces code depending on the new shape — breaking schema changes must be split across at least two deployments
+- Every migration must have a working `down` function — rollback is tested before the migration is considered complete
+- Migration filenames use timestamps (`YYYYMMDDHHMMSS_description.sql`) — never sequential numbers, to prevent merge conflicts
+
+---
+
+## Rollback Procedure
+
+1. Revert the deployment to the previous build artifact
+2. Assess whether any migrations need to be rolled back — check `tracker_schema_migrations` against the previous build's expected schema
+3. If rollback migrations are needed: run `pnpm tracker:db:rollback` for each migration added since the previous build, in reverse order
+4. Confirm `GET /tracker/health/db` returns 200
+5. Confirm a ticket can be submitted end-to-end
+6. Document the rollback in this file under the [Hotfixes and Rollbacks](#hotfixes-and-rollbacks) section with timestamp and reason
+
+---
+
+## Hotfix Procedure
+
+If an urgent fix is needed after go-live:
+
+1. Branch `tracker/hotfix-NNN` off `main` (not off `tracker`)
+2. Fix, test, CI green
+3. PR into `main` directly
+4. Immediately cherry-pick the fix into `tracker` to keep branches consistent
+5. Document the hotfix below
+
+---
+
+## Hotfixes and Rollbacks
+
+_No hotfixes or rollbacks recorded yet._

--- a/tracker/README.md
+++ b/tracker/README.md
@@ -1,0 +1,140 @@
+# Tracker
+
+A community feedback tracker for the Hanabi Competitions site. Community members can submit tickets (bugs, ideas, feedback), moderators triage them, and committee members make decisions. Integrated with Discord for identity linking and notifications.
+
+## Documentation
+
+- [ARCHITECTURE.md](./ARCHITECTURE.md) — structural conventions, non-negotiable invariants, architecture decisions
+- [PUBLISHING.md](./PUBLISHING.md) — branch strategy, commit conventions, merge policy, go-live procedures
+
+## Relationship to the Main Repo
+
+The tracker lives at `tracker/` in the root of the `hanabi-challenges` monorepo. It is a distinct package with its own server (`tracker/server`), client (`tracker/client`), and shared types (`tracker/types`). It shares the repo's:
+
+- Package manager (pnpm)
+- Toolchain (TypeScript, ESLint, Prettier, Vitest)
+- Design system (imported directly from the existing site packages)
+- CI pipeline (tracker jobs are added to the existing workflow)
+
+It does **not** share tables, routes, or authentication code with the main site — it integrates with them.
+
+## Package Layout
+
+```
+tracker/
+├── server/         ← Node.js/Express backend
+│   ├── src/
+│   │   ├── routes/
+│   │   ├── db/
+│   │   ├── services/
+│   │   ├── middleware/
+│   │   ├── migrations/
+│   │   └── bot/
+│   ├── tests/
+│   ├── package.json
+│   └── tsconfig.json
+├── client/         ← React/Vite frontend
+│   ├── src/
+│   ├── package.json
+│   └── tsconfig.json
+├── types/          ← shared request/response contracts
+│   ├── src/
+│   ├── package.json
+│   └── tsconfig.json
+├── ARCHITECTURE.md
+├── PUBLISHING.md
+└── README.md       ← this file
+```
+
+## Setup
+
+### Prerequisites
+
+- Node.js 22.x
+- pnpm 10.x
+- PostgreSQL 15+
+
+### Install
+
+```bash
+# From repo root
+pnpm install
+```
+
+### Environment Variables
+
+Copy `tracker/server/.env.example` to `tracker/server/.env` and fill in the values. Required variables are described in that file.
+
+### Database
+
+```bash
+# Run all pending tracker migrations
+pnpm tracker:db:migrate
+
+# Roll back the most recent tracker migration
+pnpm tracker:db:rollback
+
+# Reset (drop, recreate, re-migrate) — development only
+pnpm tracker:db:reset
+```
+
+### Development
+
+```bash
+# Start tracker server in dev mode (watch + reload)
+pnpm tracker:dev:server
+
+# Start tracker client in dev mode (Vite HMR)
+pnpm tracker:dev:client
+
+# Start both
+pnpm tracker:dev
+```
+
+### Tests
+
+```bash
+# Type-check all tracker packages
+pnpm tracker:typecheck
+
+# Lint all tracker packages
+pnpm tracker:lint
+
+# Unit tests
+pnpm tracker:test:unit
+
+# Integration tests (requires a running test database)
+pnpm tracker:test:integration
+```
+
+### Build
+
+```bash
+pnpm tracker:build
+```
+
+## Authentication
+
+The tracker authenticates users via the existing site's session. When a user makes a request to a tracker API endpoint:
+
+1. The tracker auth middleware reads the hanab.live username from the existing session (attached to `req.user.hanabLiveUsername` by the main site's auth middleware)
+2. The tracker does a lookup/upsert on `tracker.users` by `hanablive_username`
+3. The resolved tracker user is attached to `req.trackerUser`
+
+No separate login is required — users authenticate through the main site as they do today.
+
+## Environment Variables Reference
+
+See `tracker/server/.env.example` for the full list. Key variables:
+
+| Variable | Description |
+|---|---|
+| `TRACKER_DATABASE_URL` | PostgreSQL connection string for the tracker schema |
+| `TRACKER_DATABASE_POOL_SIZE` | Max connection pool size (default: 10) |
+| `TRACKER_PORT` | Port for the tracker server (if running as a separate process) |
+| `TRACKER_LOG_LEVEL` | Pino log level: `trace`, `debug`, `info`, `warn`, `error` (default: `info`) |
+| `TRACKER_DATABASE_SSL` | Set to `true` for SSL database connections in production |
+| `DISCORD_MOD_WEBHOOK_URL` | Discord webhook URL for mod channel notifications (activates outbound webhook) |
+| `DISCORD_BOT_TOKEN` | Discord bot token (activates bot process) |
+| `DISCORD_GUILD_ID` | Discord guild/server ID |
+| `DISCORD_MOD_ROLE_NAME` | Name of the Discord role that maps to tracker `moderator` role |


### PR DESCRIPTION
## Summary

Establishes all working conventions before any tracker code is written. This ticket produces three documents — `tracker/PUBLISHING.md`, `tracker/ARCHITECTURE.md`, and `tracker/README.md` — and configures the `tracker-main` integration branch with GitHub branch protection rules.

## Design Decisions

**Branch naming:** The spec calls for `tracker` as the integration branch and `tracker/ticket-NNN` as per-ticket branches. Git cannot hold both simultaneously (it would require `tracker` to be both a file and a directory in `.git/refs/heads/`). The integration branch is therefore named `tracker-main`. Per-ticket branches remain `tracker/ticket-NNN`. This is a permanent design decision; branch protection has been configured on `tracker-main`.

**Branch protection configuration:** Set via GitHub API before any code was committed — require PR, require status checks (typecheck, lint, build, unit-tests, integration-tests), require up-to-date branches, enforce for admins. Required status check names match the CI job names that will be introduced in Ticket 003.

## Verification Steps

```bash
# Confirm branch protection is active
gh api repos/hanabi-challenges/hanabi-challenges/branches/tracker-main/protection | jq .required_status_checks

# Read the documents
cat tracker/PUBLISHING.md
cat tracker/ARCHITECTURE.md
cat tracker/README.md
```

## Test Coverage

No automated tests — this ticket produces documentation and repository configuration only.

## Follow-On Notes

- Ticket 001 should start from `tracker-main`. Create local branch with: `git checkout -b tracker/ticket-001 origin/tracker-main`
- The required status check names (`typecheck`, `lint`, `build`, `unit-tests`, `integration-tests`) must match exactly the job IDs added to the CI workflow in Ticket 003. If the CI job names differ, branch protection will need to be updated.
- The `tracker-main` branch protection `required_approving_review_count` is set to 0 (no reviewer required) since this is a single-developer project; adjust if team review is desired.