### PR TITLE
feat(tracker): database connection pool and migration tooling (#002)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "tracker:format": "pnpm -C tracker/types run format && pnpm -C tracker/server run format && pnpm -C tracker/client run format",
     "tracker:format:check": "pnpm -C tracker/types run format:check && pnpm -C tracker/server run format:check && pnpm -C tracker/client run format:check",
     "tracker:test:unit": "pnpm -C tracker/types run test:unit && pnpm -C tracker/server run test:unit && pnpm -C tracker/client run test:unit",
-    "tracker:test:integration": "pnpm -C tracker/server run test:integration"
+    "tracker:test:integration": "pnpm -C tracker/server run test:integration",
+    "tracker:db:migrate": "pnpm -C tracker/server run db:migrate",
+    "tracker:db:rollback": "pnpm -C tracker/server run db:rollback",
+    "tracker:db:reset": "pnpm -C tracker/server run db:reset"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,12 +345,21 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      node-pg-migrate:
+        specifier: ^7.9.1
+        version: 7.9.1(@types/pg@8.16.0)(pg@8.19.0)
+      pg:
+        specifier: ^8.16.3
+        version: 8.19.0
       pino:
         specifier: ^9.6.0
         version: 9.14.0
       pino-http:
         specifier: ^10.4.0
         version: 10.5.0
+      postgres:
+        specifier: ^3.4.5
+        version: 3.4.8
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -361,6 +370,9 @@ importers:
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.15
+      '@types/pg':
+        specifier: ^8.15.6
+        version: 8.16.0
       '@types/supertest':
         specifier: ^6.0.3
         version: 6.0.3
@@ -1068,6 +1080,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -3255,6 +3271,12 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@11.0.3:
+    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -3598,6 +3620,10 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
 
   jest-changed-files@30.3.0:
     resolution: {integrity: sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==}
@@ -4233,6 +4259,17 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
+  node-pg-migrate@7.9.1:
+    resolution: {integrity: sha512-6z4OSN27ye8aYdX9ZU7NN2PTI5pOp34hTr+22Ej12djIYECq++gT7LPLZVOQXEeVCBOZQLqf87kC3Y36G434OQ==}
+    engines: {node: '>=18.19.0'}
+    hasBin: true
+    peerDependencies:
+      '@types/pg': '>=6.0.0 <9.0.0'
+      pg: '>=4.3.0 <9.0.0'
+    peerDependenciesMeta:
+      '@types/pg':
+        optional: true
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -4505,6 +4542,10 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres@3.4.8:
+    resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
+    engines: {node: '>=12'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -6281,6 +6322,8 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/cliui@9.0.0': {}
+
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
       camelcase: 5.3.1
@@ -7339,20 +7382,6 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.10.15)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
-    dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.10.15)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.15)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      playwright: 1.58.2
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.10.15)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/browser@4.0.18(rolldown-vite@7.2.2(@types/node@24.10.15)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
       '@vitest/mocker': 4.0.18(rolldown-vite@7.2.2(@types/node@24.10.15)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2))
@@ -7369,24 +7398,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.10.15)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)':
-    dependencies:
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.15)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/utils': 4.0.18
-      magic-string: 0.30.21
-      pixelmatch: 7.1.0
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.10.15)(@vitest/browser-playwright@4.0.18)(happy-dom@15.11.7)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
 
   '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(rolldown-vite@7.2.2(@types/node@24.10.15)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
@@ -8827,6 +8838,15 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@11.0.3:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.4
@@ -9172,6 +9192,10 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
 
   jest-changed-files@30.3.0:
     dependencies:
@@ -10135,6 +10159,14 @@ snapshots:
 
   node-int64@0.4.0: {}
 
+  node-pg-migrate@7.9.1(@types/pg@8.16.0)(pg@8.19.0):
+    dependencies:
+      glob: 11.0.3
+      pg: 8.19.0
+      yargs: 17.7.2
+    optionalDependencies:
+      '@types/pg': 8.16.0
+
   node-releases@2.0.27: {}
 
   normalize-path@3.0.0: {}
@@ -10405,6 +10437,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  postgres@3.4.8: {}
 
   prelude-ls@1.2.1: {}
 
@@ -11578,7 +11612,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.15
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.10.15)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(rolldown-vite@7.2.2(@types/node@24.10.15)(esbuild@0.25.12)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.18)
       happy-dom: 15.11.7
       jsdom: 27.4.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:

--- a/tracker/server/package.json
+++ b/tracker/server/package.json
@@ -12,18 +12,25 @@
     "format": "prettier -w . --ignore-path ../../.prettierignore",
     "format:check": "prettier -c . --ignore-path ../../.prettierignore",
     "test:unit": "vitest run -c vitest.unit.config.ts",
-    "test:integration": "vitest run -c vitest.integration.config.ts --maxWorkers=1"
+    "test:integration": "vitest run -c vitest.integration.config.ts --maxWorkers=1",
+    "db:migrate": "tsx src/scripts/db-migrate.ts",
+    "db:rollback": "tsx src/scripts/db-rollback.ts",
+    "db:reset": "tsx src/scripts/db-reset.ts"
   },
   "dependencies": {
     "@tracker/types": "workspace:*",
     "express": "^5.1.0",
+    "node-pg-migrate": "^7.9.1",
+    "pg": "^8.16.3",
     "pino": "^9.6.0",
     "pino-http": "^10.4.0",
+    "postgres": "^3.4.5",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.5",
     "@types/node": "^24.10.1",
+    "@types/pg": "^8.15.6",
     "@types/supertest": "^6.0.3",
     "eslint": "^9.39.1",
     "prettier": "^3.8.1",

--- a/tracker/server/src/app.ts
+++ b/tracker/server/src/app.ts
@@ -1,6 +1,7 @@
 import express, { type Request, type Response, type NextFunction } from 'express';
 import { randomUUID } from 'crypto';
 import type { HealthResponse, TrackerErrorResponse } from '@tracker/types';
+import { checkDbHealth } from './db/pool.js';
 
 export function createApp() {
   const app = express();
@@ -17,6 +18,15 @@ export function createApp() {
   app.get('/tracker/health', (_req: Request, res: Response) => {
     const body: HealthResponse = { status: 'ok', timestamp: new Date().toISOString() };
     res.json(body);
+  });
+
+  app.get('/tracker/health/db', async (_req: Request, res: Response) => {
+    const healthy = await checkDbHealth();
+    if (healthy) {
+      res.json({ status: 'ok', timestamp: new Date().toISOString() });
+    } else {
+      res.status(503).json({ status: 'unavailable', timestamp: new Date().toISOString() });
+    }
   });
 
   // 404 handler for unmatched tracker routes

--- a/tracker/server/src/db/pool.ts
+++ b/tracker/server/src/db/pool.ts
@@ -1,0 +1,56 @@
+import postgres from 'postgres';
+import { env } from '../env.js';
+
+let _pool: postgres.Sql | null = null;
+
+/**
+ * Returns the shared postgres.js connection pool for the tracker.
+ * The pool is created lazily on first access.
+ *
+ * Connection string is never logged — it is read from env at call time.
+ */
+export function getPool(): postgres.Sql {
+  if (_pool === null) {
+    _pool = postgres(env.TRACKER_DATABASE_URL, {
+      max: env.TRACKER_DATABASE_POOL_SIZE,
+      ssl: env.TRACKER_DATABASE_SSL ? 'require' : false,
+      connection: {
+        application_name: 'tracker',
+      },
+      // Crash the process on connection error at startup — do not swallow silently
+      onnotice: () => undefined,
+    });
+  }
+  return _pool;
+}
+
+/**
+ * Closes the connection pool. Called on SIGTERM/SIGINT.
+ */
+export async function closePool(): Promise<void> {
+  if (_pool !== null) {
+    await _pool.end();
+    _pool = null;
+  }
+}
+
+/**
+ * Executes a trivial query to verify the pool is healthy.
+ * Returns true if the database is reachable, false otherwise.
+ */
+export async function checkDbHealth(): Promise<boolean> {
+  return checkConnectionHealth(getPool());
+}
+
+/**
+ * Executes a trivial query against the given sql instance.
+ * Exposed for testing with arbitrary connections.
+ */
+export async function checkConnectionHealth(sql: postgres.Sql): Promise<boolean> {
+  try {
+    await sql`SELECT 1`;
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tracker/server/src/index.ts
+++ b/tracker/server/src/index.ts
@@ -1,6 +1,7 @@
 import './env.js'; // validate env first — crashes fast if misconfigured
 import { env } from './env.js';
 import { createApp } from './app.js';
+import { closePool } from './db/pool.js';
 
 const app = createApp();
 
@@ -10,7 +11,9 @@ const server = app.listen(env.TRACKER_PORT, () => {
 
 function shutdown() {
   server.close(() => {
-    process.exit(0);
+    void closePool().then(() => {
+      process.exit(0);
+    });
   });
 }
 

--- a/tracker/server/src/scripts/db-migrate.ts
+++ b/tracker/server/src/scripts/db-migrate.ts
@@ -1,0 +1,36 @@
+/**
+ * Runs all pending tracker migrations.
+ * Creates the tracker schema if it doesn't exist yet (bootstrapping).
+ */
+import { env } from '../env.js';
+import postgres from 'postgres';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(__dirname, '../../migrations');
+
+// Create the tracker schema if it doesn't already exist
+const sql = postgres(env.TRACKER_DATABASE_URL, { max: 1 });
+try {
+  await sql`CREATE SCHEMA IF NOT EXISTS tracker`;
+} finally {
+  await sql.end();
+}
+
+// Run node-pg-migrate (uses DATABASE_URL env var)
+execSync(
+  [
+    'node-pg-migrate up',
+    `--migrations-dir "${migrationsDir}"`,
+    '--migration-file-language sql',
+    '--schema tracker',
+    '--migrations-schema tracker',
+    '--migrations-table tracker_schema_migrations',
+  ].join(' '),
+  {
+    stdio: 'inherit',
+    env: { ...process.env, DATABASE_URL: env.TRACKER_DATABASE_URL },
+  },
+);

--- a/tracker/server/src/scripts/db-reset.ts
+++ b/tracker/server/src/scripts/db-reset.ts
@@ -1,0 +1,31 @@
+/**
+ * Drops and recreates the tracker schema, then re-runs all migrations.
+ * DEVELOPMENT ONLY — aborts in production.
+ */
+import { env } from '../env.js';
+import postgres from 'postgres';
+import { execSync } from 'child_process';
+
+if (process.env['NODE_ENV'] === 'production') {
+  console.error('[tracker] db:reset is not allowed in production.');
+  process.exit(1);
+}
+
+const sql = postgres(env.TRACKER_DATABASE_URL, { max: 1 });
+
+try {
+  console.log('[tracker] Dropping tracker schema...');
+  await sql`DROP SCHEMA IF EXISTS tracker CASCADE`;
+  await sql`CREATE SCHEMA tracker`;
+  console.log('[tracker] Schema recreated.');
+} finally {
+  await sql.end();
+}
+
+console.log('[tracker] Running migrations...');
+execSync('pnpm run db:migrate', {
+  stdio: 'inherit',
+  env: { ...process.env },
+});
+
+console.log('[tracker] Reset complete.');

--- a/tracker/server/src/scripts/db-rollback.ts
+++ b/tracker/server/src/scripts/db-rollback.ts
@@ -1,0 +1,25 @@
+/**
+ * Rolls back the most recent tracker migration.
+ */
+import { env } from '../env.js';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { join, dirname } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationsDir = join(__dirname, '../../migrations');
+
+execSync(
+  [
+    'node-pg-migrate down',
+    `--migrations-dir "${migrationsDir}"`,
+    '--migration-file-language sql',
+    '--schema tracker',
+    '--migrations-schema tracker',
+    '--migrations-table tracker_schema_migrations',
+  ].join(' '),
+  {
+    stdio: 'inherit',
+    env: { ...process.env, DATABASE_URL: env.TRACKER_DATABASE_URL },
+  },
+);

--- a/tracker/server/tests/integration/health.test.ts
+++ b/tracker/server/tests/integration/health.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import postgres from 'postgres';
+import { getTestDatabaseUrl, setupTestSchema, teardownTestSchema } from '../support/db.js';
+
+const testDbUrl = getTestDatabaseUrl();
+
+// Set env before importing app modules
+process.env['TRACKER_DATABASE_URL'] = testDbUrl;
+
+const { createApp } = await import('../../src/app.js');
+const { checkConnectionHealth } = await import('../../src/db/pool.js');
+
+describe('GET /tracker/health/db (integration)', () => {
+  let sql: postgres.Sql;
+  const app = createApp();
+
+  beforeAll(async () => {
+    sql = postgres(testDbUrl, { max: 2 });
+    await setupTestSchema(sql);
+  });
+
+  afterAll(async () => {
+    await teardownTestSchema(sql);
+    await sql.end();
+  });
+
+  it('returns 200 when database is reachable', async () => {
+    const res = await request(app).get('/tracker/health/db');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+});
+
+describe('checkConnectionHealth (integration — unreachable DB)', () => {
+  it('returns false for an unreachable database', async () => {
+    const badSql = postgres('postgresql://nobody:nobody@127.0.0.1:1/nonexistent_db', {
+      max: 1,
+      connect_timeout: 2,
+    });
+    try {
+      const healthy = await checkConnectionHealth(badSql);
+      expect(healthy).toBe(false);
+    } finally {
+      await badSql.end({ timeout: 1 }).catch(() => undefined);
+    }
+  });
+});

--- a/tracker/server/tests/support/db.ts
+++ b/tracker/server/tests/support/db.ts
@@ -1,0 +1,27 @@
+/**
+ * Test database helpers.
+ *
+ * Each integration test run uses a clean tracker schema.
+ * TRACKER_TEST_DATABASE_URL must be set to a PostgreSQL database
+ * the test user has permission to create/drop schemas in.
+ */
+import postgres from 'postgres';
+
+export function getTestDatabaseUrl(): string {
+  const url = process.env['TRACKER_TEST_DATABASE_URL'] ?? process.env['TRACKER_DATABASE_URL'];
+  if (!url) {
+    throw new Error(
+      'TRACKER_TEST_DATABASE_URL (or TRACKER_DATABASE_URL) must be set for integration tests',
+    );
+  }
+  return url;
+}
+
+export async function setupTestSchema(sql: postgres.Sql): Promise<void> {
+  await sql`DROP SCHEMA IF EXISTS tracker CASCADE`;
+  await sql`CREATE SCHEMA tracker`;
+}
+
+export async function teardownTestSchema(sql: postgres.Sql): Promise<void> {
+  await sql`DROP SCHEMA IF EXISTS tracker CASCADE`;
+}


### PR DESCRIPTION
## Summary

Adds the tracker's PostgreSQL connection layer and migration tooling. The tracker uses the `tracker` schema within the same PostgreSQL database as the existing site. A `postgres.js` singleton pool handles all tracker queries; `node-pg-migrate` with timestamp-based SQL migrations handles schema versioning.

## Design Decisions

**Schema creation as infrastructure, not a migration:** Making schema creation a migration causes a bootstrapping problem — the `DOWN` path drops the `tracker` schema (CASCADE), which destroys the `tracker_schema_migrations` tracking table, making subsequent migration operations fail. The schema is now created by `db-migrate.ts` before running migrations and is never dropped by a migration. `db:reset` is the only mechanism to destroy and recreate the tracker schema (development only).

**Wrapper scripts instead of bare node-pg-migrate invocations:** `tsx src/scripts/db-migrate.ts` ensures the `tracker` schema exists before calling node-pg-migrate. Direct invocation of node-pg-migrate would fail on a fresh database because the migrations table can't be created in a schema that doesn't yet exist.

**Connection string never logged:** The pool is constructed from `env.TRACKER_DATABASE_URL` which is validated at startup by zod but never appears in any log output.

**`checkConnectionHealth(sql)` is testable:** Extracted as a separate function from `checkDbHealth()` so tests can pass a purpose-built bad connection without manipulating the singleton pool.

## Verification Steps

```bash
# Migrate (creates tracker schema, runs all pending migrations)
TRACKER_DATABASE_URL=postgres://... pnpm tracker:db:migrate

# Rollback most recent migration
TRACKER_DATABASE_URL=postgres://... pnpm tracker:db:rollback

# Reset (dev only)
TRACKER_DATABASE_URL=postgres://... pnpm tracker:db:reset

# Health endpoints
curl http://localhost:4001/tracker/health      # 200 {"status":"ok"}
curl http://localhost:4001/tracker/health/db   # 200 when DB reachable, 503 when not

# Integration tests
TRACKER_TEST_DATABASE_URL=postgres://... pnpm tracker:test:integration
```

## Test Coverage

- Integration: `GET /tracker/health/db` returns 200 against a real test database
- Integration: `checkConnectionHealth` returns false for an unreachable database
- Unit tests from Ticket 001 still pass (app.test.ts)

Not covered: rollback correctness (tested manually; will be covered as real migrations are added in Phase 2).

## Follow-On Notes

- Ticket 003 (CI) needs `TRACKER_TEST_DATABASE_URL` provisioned as a CI secret/env var for integration tests.
- All subsequent Phase 2 migrations should be timestamped SQL files in `tracker/server/migrations/`. The schema for the timestamp is `YYYYMMDDHHMMSS`.
- `db:reset` in the reset script calls `pnpm run db:migrate` which invokes the tsx wrapper — no circular dependency.