### PR TITLE
migration(tracker): core lookup tables (#004)

### DIFF
--- a/tracker/server/migrations/20260327000000_core_lookup_tables.sql
+++ b/tracker/server/migrations/20260327000000_core_lookup_tables.sql
@@ -1,0 +1,144 @@
+-- Up Migration
+
+CREATE TABLE ticket_types (
+  id         SMALLINT NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  name       TEXT     NOT NULL,
+  slug       TEXT     NOT NULL UNIQUE,
+  sort_order SMALLINT NOT NULL DEFAULT 0
+);
+
+INSERT INTO ticket_types (name, slug, sort_order) VALUES
+  ('Bug',             'bug',             1),
+  ('Feature Request', 'feature_request', 2),
+  ('Question',        'question',        3),
+  ('Feedback',        'feedback',        4),
+  ('Other',           'other',           5);
+
+CREATE TABLE domains (
+  id         SMALLINT NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  name       TEXT     NOT NULL,
+  slug       TEXT     NOT NULL UNIQUE,
+  sort_order SMALLINT NOT NULL DEFAULT 0
+);
+
+INSERT INTO domains (name, slug, sort_order) VALUES
+  ('Gameplay & Rules', 'gameplay',     1),
+  ('Scoring',          'scoring',      2),
+  ('Registration',     'registration', 3),
+  ('Interface',        'interface',    4),
+  ('Matchmaking',      'matchmaking',  5),
+  ('Events & Formats', 'events',       6),
+  ('Discord',          'discord',      7),
+  ('Other',            'other',        8);
+
+CREATE TABLE statuses (
+  id          SMALLINT NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  name        TEXT     NOT NULL,
+  slug        TEXT     NOT NULL UNIQUE,
+  description TEXT     NOT NULL DEFAULT '',
+  is_terminal BOOLEAN  NOT NULL DEFAULT FALSE
+);
+
+INSERT INTO statuses (name, slug, description, is_terminal) VALUES
+  ('Submitted', 'submitted', 'Ticket has been submitted and is awaiting triage.',                    FALSE),
+  ('Triaged',   'triaged',   'Ticket has been reviewed and accepted for consideration.',             FALSE),
+  ('In Review', 'in_review', 'Ticket is under active committee review.',                             FALSE),
+  ('Decided',   'decided',   'Committee has made a decision on this ticket.',                        FALSE),
+  ('Resolved',  'resolved',  'Ticket has been implemented or otherwise resolved.',                   TRUE),
+  ('Rejected',  'rejected',  'Ticket has been rejected as out of scope or not actionable.',          TRUE),
+  ('Closed',    'closed',    'Ticket has been closed without a decision (duplicate, invalid, etc.).', TRUE);
+
+CREATE TABLE roles (
+  id   SMALLINT NOT NULL PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  name TEXT     NOT NULL UNIQUE
+);
+
+INSERT INTO roles (name) VALUES
+  ('community_member'),
+  ('moderator'),
+  ('committee');
+
+CREATE TABLE valid_transitions (
+  from_status_id SMALLINT NOT NULL REFERENCES statuses (id),
+  to_status_id   SMALLINT NOT NULL REFERENCES statuses (id),
+  role_id        SMALLINT NOT NULL REFERENCES roles (id),
+  PRIMARY KEY (from_status_id, to_status_id, role_id),
+  CHECK (from_status_id <> to_status_id)
+);
+
+-- Seed valid transitions using slugs to avoid hardcoded identity values.
+WITH
+  s AS (SELECT id, slug FROM statuses),
+  r AS (SELECT id, name FROM roles)
+INSERT INTO valid_transitions (from_status_id, to_status_id, role_id)
+SELECT s_from.id, s_to.id, r.id
+FROM (VALUES
+  -- moderator: triage incoming tickets
+  ('submitted', 'triaged',   'moderator'),
+  ('submitted', 'rejected',  'moderator'),
+  ('submitted', 'closed',    'moderator'),
+  -- moderator: advance or close triaged tickets
+  ('triaged',   'in_review', 'moderator'),
+  ('triaged',   'rejected',  'moderator'),
+  ('triaged',   'closed',    'moderator'),
+  -- moderator: close or resolve decided tickets
+  ('decided',   'resolved',  'moderator'),
+  ('decided',   'closed',    'moderator'),
+  -- committee: same control over incoming tickets as moderator
+  ('submitted', 'triaged',   'committee'),
+  ('submitted', 'rejected',  'committee'),
+  ('submitted', 'closed',    'committee'),
+  -- committee: advance or close triaged tickets
+  ('triaged',   'in_review', 'committee'),
+  ('triaged',   'rejected',  'committee'),
+  ('triaged',   'closed',    'committee'),
+  -- committee: decide or close in-review tickets
+  ('in_review', 'decided',   'committee'),
+  ('in_review', 'closed',    'committee'),
+  -- committee: resolve or close decided tickets
+  ('decided',   'resolved',  'committee'),
+  ('decided',   'closed',    'committee')
+) AS t (from_slug, to_slug, role_name)
+JOIN s AS s_from ON s_from.slug = t.from_slug
+JOIN s AS s_to   ON s_to.slug   = t.to_slug
+JOIN r           ON r.name      = t.role_name;
+
+CREATE TABLE permissions (
+  role_id SMALLINT NOT NULL REFERENCES roles (id),
+  action  TEXT     NOT NULL,
+  PRIMARY KEY (role_id, action)
+);
+
+-- Seed permissions.
+WITH r AS (SELECT id, name FROM roles)
+INSERT INTO permissions (role_id, action)
+SELECT r.id, t.action
+FROM (VALUES
+  ('community_member', 'ticket.create'),
+  ('community_member', 'ticket.comment'),
+  ('community_member', 'ticket.vote'),
+  ('moderator',        'ticket.create'),
+  ('moderator',        'ticket.comment'),
+  ('moderator',        'ticket.vote'),
+  ('moderator',        'ticket.triage'),
+  ('moderator',        'ticket.transition'),
+  ('moderator',        'ticket.view_internal'),
+  ('committee',        'ticket.create'),
+  ('committee',        'ticket.comment'),
+  ('committee',        'ticket.vote'),
+  ('committee',        'ticket.triage'),
+  ('committee',        'ticket.transition'),
+  ('committee',        'ticket.view_internal'),
+  ('committee',        'ticket.decide'),
+  ('committee',        'user.role.assign')
+) AS t (role_name, action)
+JOIN r ON r.name = t.role_name;
+
+-- Down Migration
+
+DROP TABLE permissions;
+DROP TABLE valid_transitions;
+DROP TABLE roles;
+DROP TABLE statuses;
+DROP TABLE domains;
+DROP TABLE ticket_types;

--- a/tracker/server/tests/integration/migrations/core_lookup_tables.test.ts
+++ b/tracker/server/tests/integration/migrations/core_lookup_tables.test.ts
@@ -6,10 +6,7 @@ import { fileURLToPath } from 'url';
 import { getTestDatabaseUrl, setupTestSchema, teardownTestSchema } from '../../support/db.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const migrationPath = join(
-  __dirname,
-  '../../../migrations/20260327000000_core_lookup_tables.sql',
-);
+const migrationPath = join(__dirname, '../../../migrations/20260327000000_core_lookup_tables.sql');
 
 function parseMigration(filePath: string): { up: string; down: string } {
   const content = readFileSync(filePath, 'utf8');

--- a/tracker/server/tests/integration/migrations/core_lookup_tables.test.ts
+++ b/tracker/server/tests/integration/migrations/core_lookup_tables.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { getTestDatabaseUrl, setupTestSchema, teardownTestSchema } from '../../support/db.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const migrationPath = join(
+  __dirname,
+  '../../../migrations/20260327000000_core_lookup_tables.sql',
+);
+
+function parseMigration(filePath: string): { up: string; down: string } {
+  const content = readFileSync(filePath, 'utf8');
+  const [upRaw, downRaw] = content.split('-- Down Migration');
+  if (!upRaw || !downRaw) throw new Error('Migration missing Up or Down section');
+  return {
+    up: upRaw.replace('-- Up Migration', '').trim(),
+    down: downRaw.trim(),
+  };
+}
+
+const testDbUrl = getTestDatabaseUrl();
+const { up, down } = parseMigration(migrationPath);
+
+describe('migration: 20260327000000_core_lookup_tables', () => {
+  let sql: postgres.Sql;
+
+  beforeAll(async () => {
+    sql = postgres(testDbUrl, { max: 2 });
+    await setupTestSchema(sql);
+    await sql.unsafe(up);
+  });
+
+  afterAll(async () => {
+    await teardownTestSchema(sql);
+    await sql.end();
+  });
+
+  // ── ticket_types ────────────────────────────────────────────────────────────
+
+  it('creates ticket_types with all expected slugs', async () => {
+    const rows = await sql<{ slug: string }[]>`SELECT slug FROM ticket_types ORDER BY sort_order`;
+    expect(rows.map((r) => r.slug)).toEqual([
+      'bug',
+      'feature_request',
+      'question',
+      'feedback',
+      'other',
+    ]);
+  });
+
+  // ── domains ─────────────────────────────────────────────────────────────────
+
+  it('creates domains with all expected slugs', async () => {
+    const rows = await sql<{ slug: string }[]>`SELECT slug FROM domains ORDER BY sort_order`;
+    expect(rows.map((r) => r.slug)).toEqual([
+      'gameplay',
+      'scoring',
+      'registration',
+      'interface',
+      'matchmaking',
+      'events',
+      'discord',
+      'other',
+    ]);
+  });
+
+  // ── statuses ─────────────────────────────────────────────────────────────────
+
+  it('creates statuses with correct slugs and terminal flags', async () => {
+    const rows = await sql<
+      {
+        slug: string;
+        is_terminal: boolean;
+      }[]
+    >`SELECT slug, is_terminal FROM statuses ORDER BY id`;
+
+    const terminal = rows.filter((r) => r.is_terminal).map((r) => r.slug);
+    const nonTerminal = rows.filter((r) => !r.is_terminal).map((r) => r.slug);
+
+    expect(terminal.sort()).toEqual(['closed', 'rejected', 'resolved']);
+    expect(nonTerminal.sort()).toEqual(['decided', 'in_review', 'submitted', 'triaged']);
+  });
+
+  // ── roles ────────────────────────────────────────────────────────────────────
+
+  it('creates exactly three roles', async () => {
+    const rows = await sql<{ name: string }[]>`SELECT name FROM roles ORDER BY id`;
+    expect(rows.map((r) => r.name)).toEqual(['community_member', 'moderator', 'committee']);
+  });
+
+  // ── valid_transitions ────────────────────────────────────────────────────────
+
+  it('seeds valid_transitions for moderator and committee only', async () => {
+    const rows = await sql<{ role_name: string }[]>`
+      SELECT DISTINCT r.name AS role_name
+      FROM valid_transitions vt
+      JOIN roles r ON r.id = vt.role_id
+      ORDER BY r.name
+    `;
+    expect(rows.map((r) => r.role_name)).toEqual(['committee', 'moderator']);
+  });
+
+  it('allows moderator to triage submitted tickets', async () => {
+    const [row] = await sql<{ count: string }[]>`
+      SELECT count(*) FROM valid_transitions vt
+      JOIN statuses s_from ON s_from.id = vt.from_status_id
+      JOIN statuses s_to   ON s_to.id   = vt.to_status_id
+      JOIN roles r         ON r.id       = vt.role_id
+      WHERE s_from.slug = 'submitted'
+        AND s_to.slug   = 'triaged'
+        AND r.name      = 'moderator'
+    `;
+    expect(Number(row?.count)).toBe(1);
+  });
+
+  it('does not allow community_member any transitions', async () => {
+    const [row] = await sql<{ count: string }[]>`
+      SELECT count(*) FROM valid_transitions vt
+      JOIN roles r ON r.id = vt.role_id
+      WHERE r.name = 'community_member'
+    `;
+    expect(Number(row?.count)).toBe(0);
+  });
+
+  it('rejects a self-transition (check constraint)', async () => {
+    const statusRows = await sql<{ status_id: number }[]>`
+      SELECT id AS status_id FROM statuses WHERE slug = 'submitted'
+    `;
+    const roleRows = await sql<{ role_id: number }[]>`
+      SELECT id AS role_id FROM roles WHERE name = 'moderator'
+    `;
+    const statusId = statusRows[0]?.status_id;
+    const roleId = roleRows[0]?.role_id;
+    if (statusId === undefined || roleId === undefined) throw new Error('seed data missing');
+    await expect(
+      sql`INSERT INTO valid_transitions (from_status_id, to_status_id, role_id)
+          VALUES (${statusId}, ${statusId}, ${roleId})`,
+    ).rejects.toThrow();
+  });
+
+  // ── permissions ──────────────────────────────────────────────────────────────
+
+  it('grants ticket.create to all roles', async () => {
+    const rows = await sql<{ role_name: string }[]>`
+      SELECT r.name AS role_name
+      FROM permissions p
+      JOIN roles r ON r.id = p.role_id
+      WHERE p.action = 'ticket.create'
+      ORDER BY r.name
+    `;
+    expect(rows.map((r) => r.role_name)).toEqual(['committee', 'community_member', 'moderator']);
+  });
+
+  it('grants ticket.decide only to committee', async () => {
+    const rows = await sql<{ role_name: string }[]>`
+      SELECT r.name AS role_name
+      FROM permissions p
+      JOIN roles r ON r.id = p.role_id
+      WHERE p.action = 'ticket.decide'
+    `;
+    expect(rows.map((r) => r.role_name)).toEqual(['committee']);
+  });
+
+  it('grants user.role.assign only to committee', async () => {
+    const rows = await sql<{ role_name: string }[]>`
+      SELECT r.name AS role_name
+      FROM permissions p
+      JOIN roles r ON r.id = p.role_id
+      WHERE p.action = 'user.role.assign'
+    `;
+    expect(rows.map((r) => r.role_name)).toEqual(['committee']);
+  });
+
+  // ── rollback ─────────────────────────────────────────────────────────────────
+
+  it('down migration drops all tables', async () => {
+    await sql.unsafe(down);
+
+    for (const table of [
+      'permissions',
+      'valid_transitions',
+      'roles',
+      'statuses',
+      'domains',
+      'ticket_types',
+    ]) {
+      const [row] = await sql<{ exists: boolean }[]>`
+        SELECT EXISTS (
+          SELECT 1 FROM information_schema.tables
+          WHERE table_schema = 'tracker' AND table_name = ${table}
+        ) AS exists
+      `;
+      expect(row?.exists, `${table} should not exist after rollback`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Creates the foundational lookup tables for the tracker schema. These tables have no dependencies on user or ticket data and must exist before any other tracker table can be created. All tables are seeded at migration time.

**Tables created:**
- `ticket_types` — what kind of ticket (bug, feature request, question, feedback, other)
- `domains` — which area of the product (gameplay, scoring, registration, interface, matchmaking, events, discord, other)
- `statuses` — ticket lifecycle states with `is_terminal` flag; terminal statuses are resolved, rejected, closed
- `roles` — tracker roles (community_member, moderator, committee)
- `valid_transitions` — which status changes each role may perform; community_member has none
- `permissions` — which actions each role may perform; seeded per architecture spec

## Design Decisions

**Slug-based seeding for `valid_transitions`:** The transition seed data uses a CTE over the `statuses` and `roles` tables (joining on slugs) rather than hardcoded identity values. This makes the seed data self-documenting and avoids coupling to GENERATED ALWAYS AS IDENTITY sequences.

**`permissions` included here:** ARCHITECTURE.md specifies that permission data is seeded at migration time and is not user-configurable. It belongs with the `roles` table it depends on.

**`is_terminal` on statuses:** Drives lifecycle enforcement — the lifecycle engine will refuse further transitions out of terminal statuses without needing a hardcoded list of slugs in application code.

**community_member has no valid transitions:** Community members can create and comment on tickets but cannot change status. This is enforced at the data layer (no rows in `valid_transitions` for that role) in addition to route-level permission checks.

## Verification Steps

```bash
# Run integration tests (requires a local postgres instance)
TRACKER_DATABASE_URL=postgresql://... TRACKER_TEST_DATABASE_URL=postgresql://... pnpm tracker:test:integration

# Apply migration to a local database
pnpm tracker:db:migrate

# Roll back
pnpm tracker:db:rollback
```

## Test Coverage

Integration tests in `tests/integration/migrations/core_lookup_tables.test.ts` verify:
- All expected slugs present in each lookup table
- Terminal/non-terminal status classification
- Exactly three roles seeded
- Valid transitions seeded for moderator and committee only
- Specific transition coverage (moderator can triage submitted → triaged)
- community_member has zero transitions
- Self-transition rejected by CHECK constraint
- All six tables dropped cleanly by the down migration

Not covered: FK violations from other tables (no other tables exist yet).

## Follow-On Notes

- TICKET 005 (users table) depends on `roles` from this migration
- TICKET 006 (tickets table) depends on `ticket_types`, `domains`, and `statuses`
- The lifecycle engine (later ticket) should query `valid_transitions` at runtime — never hardcode transition rules in application code