### PR TITLE
migration(tracker): users and role assignments (#005)

### DIFF
--- a/tracker/server/migrations/20260327120000_users.sql
+++ b/tracker/server/migrations/20260327120000_users.sql
@@ -1,0 +1,38 @@
+-- Up Migration
+
+CREATE TABLE users (
+  id                 UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+  hanablive_username TEXT        NOT NULL UNIQUE,
+  display_name       TEXT        NOT NULL,
+  account_status     TEXT        NOT NULL DEFAULT 'active'
+                     CHECK (account_status IN ('active', 'restricted', 'banned')),
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Tracks explicit role assignments for moderator and committee.
+-- community_member is the implicit default and is never stored here.
+-- Only one active assignment per (user, role) is permitted at any time;
+-- enforced by the partial unique index below.
+CREATE TABLE user_role_assignments (
+  id         UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID        NOT NULL REFERENCES users (id),
+  role_id    SMALLINT    NOT NULL REFERENCES roles (id),
+  source     TEXT        NOT NULL DEFAULT 'manual'
+             CHECK (source IN ('manual', 'discord_sync')),
+  granted_by UUID        REFERENCES users (id),
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  revoked_at TIMESTAMPTZ,
+  revoked_by UUID        REFERENCES users (id)
+);
+
+-- Prevents the same role from being actively assigned twice to the same user.
+CREATE UNIQUE INDEX uq_active_user_role
+  ON user_role_assignments (user_id, role_id)
+  WHERE revoked_at IS NULL;
+
+-- Down Migration
+
+DROP INDEX uq_active_user_role;
+DROP TABLE user_role_assignments;
+DROP TABLE users;

--- a/tracker/server/tests/integration/migrations/core_lookup_tables.test.ts
+++ b/tracker/server/tests/integration/migrations/core_lookup_tables.test.ts
@@ -25,7 +25,7 @@ describe('migration: 20260327000000_core_lookup_tables', () => {
   let sql: postgres.Sql;
 
   beforeAll(async () => {
-    sql = postgres(testDbUrl, { max: 2 });
+    sql = postgres(testDbUrl, { max: 2, connection: { search_path: 'tracker' } });
     await setupTestSchema(sql);
     await sql.unsafe(up);
   });

--- a/tracker/server/tests/integration/migrations/users.test.ts
+++ b/tracker/server/tests/integration/migrations/users.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { getTestDatabaseUrl, setupTestSchema, teardownTestSchema } from '../../support/db.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function parseMigration(filePath: string): { up: string; down: string } {
+  const content = readFileSync(filePath, 'utf8');
+  const [upRaw, downRaw] = content.split('-- Down Migration');
+  if (!upRaw || !downRaw) throw new Error('Migration missing Up or Down section');
+  return {
+    up: upRaw.replace('-- Up Migration', '').trim(),
+    down: downRaw.trim(),
+  };
+}
+
+const testDbUrl = getTestDatabaseUrl();
+
+const { up: upLookup, down: downLookup } = parseMigration(
+  join(__dirname, '../../../migrations/20260327000000_core_lookup_tables.sql'),
+);
+const { up: upUsers, down: downUsers } = parseMigration(
+  join(__dirname, '../../../migrations/20260327120000_users.sql'),
+);
+
+describe('migration: 20260327120000_users', () => {
+  let sql: postgres.Sql;
+
+  beforeAll(async () => {
+    sql = postgres(testDbUrl, { max: 2, connection: { search_path: 'tracker' } });
+    await setupTestSchema(sql);
+    // Users depends on roles from the core lookup tables migration.
+    await sql.unsafe(upLookup);
+    await sql.unsafe(upUsers);
+  });
+
+  afterAll(async () => {
+    await teardownTestSchema(sql);
+    await sql.end();
+  });
+
+  // ── users ────────────────────────────────────────────────────────────────────
+
+  it('creates a user and retrieves it by hanablive_username', async () => {
+    await sql`
+      INSERT INTO users (hanablive_username, display_name)
+      VALUES ('alice', 'Alice')
+    `;
+    const rows = await sql<{ display_name: string; account_status: string }[]>`
+      SELECT display_name, account_status FROM users WHERE hanablive_username = 'alice'
+    `;
+    expect(rows[0]?.display_name).toBe('Alice');
+    expect(rows[0]?.account_status).toBe('active');
+  });
+
+  it('rejects duplicate hanablive_username', async () => {
+    await expect(
+      sql`INSERT INTO users (hanablive_username, display_name) VALUES ('alice', 'Alice2')`,
+    ).rejects.toThrow();
+  });
+
+  it('rejects an invalid account_status value', async () => {
+    await expect(
+      sql`INSERT INTO users (hanablive_username, display_name, account_status)
+          VALUES ('bob', 'Bob', 'suspended')`,
+    ).rejects.toThrow();
+  });
+
+  // ── user_role_assignments ────────────────────────────────────────────────────
+
+  it('assigns a role and reads it back', async () => {
+    const [moderatorRole] = await sql<{ id: number }[]>`
+      SELECT id FROM roles WHERE name = 'moderator'
+    `;
+    if (!moderatorRole) throw new Error('moderator role not found');
+
+    const [user] = await sql<{ id: string }[]>`
+      SELECT id FROM users WHERE hanablive_username = 'alice'
+    `;
+    if (!user) throw new Error('alice not found');
+
+    await sql`
+      INSERT INTO user_role_assignments (user_id, role_id)
+      VALUES (${user.id}, ${moderatorRole.id})
+    `;
+
+    const [assignment] = await sql<{ source: string; revoked_at: Date | null }[]>`
+      SELECT source, revoked_at FROM user_role_assignments
+      WHERE user_id = ${user.id} AND role_id = ${moderatorRole.id}
+    `;
+    expect(assignment?.source).toBe('manual');
+    expect(assignment?.revoked_at).toBeNull();
+  });
+
+  it('rejects a duplicate active role assignment (partial unique index)', async () => {
+    const [moderatorRole] = await sql<{ id: number }[]>`
+      SELECT id FROM roles WHERE name = 'moderator'
+    `;
+    const [user] = await sql<{ id: string }[]>`
+      SELECT id FROM users WHERE hanablive_username = 'alice'
+    `;
+    if (!moderatorRole || !user) throw new Error('seed data missing');
+
+    await expect(
+      sql`INSERT INTO user_role_assignments (user_id, role_id)
+          VALUES (${user.id}, ${moderatorRole.id})`,
+    ).rejects.toThrow();
+  });
+
+  it('allows a second assignment after revocation', async () => {
+    const [moderatorRole] = await sql<{ id: number }[]>`
+      SELECT id FROM roles WHERE name = 'moderator'
+    `;
+    const [user] = await sql<{ id: string }[]>`
+      SELECT id FROM users WHERE hanablive_username = 'alice'
+    `;
+    if (!moderatorRole || !user) throw new Error('seed data missing');
+
+    // Revoke the existing assignment.
+    await sql`
+      UPDATE user_role_assignments
+      SET revoked_at = now()
+      WHERE user_id = ${user.id} AND role_id = ${moderatorRole.id} AND revoked_at IS NULL
+    `;
+
+    // Now a new active assignment is allowed.
+    await sql`
+      INSERT INTO user_role_assignments (user_id, role_id)
+      VALUES (${user.id}, ${moderatorRole.id})
+    `;
+
+    const rows = await sql<{ revoked_at: Date | null }[]>`
+      SELECT revoked_at FROM user_role_assignments
+      WHERE user_id = ${user.id} AND role_id = ${moderatorRole.id}
+      ORDER BY granted_at
+    `;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.revoked_at).not.toBeNull();
+    expect(rows[1]?.revoked_at).toBeNull();
+  });
+
+  it('rejects an invalid source value', async () => {
+    const [user] = await sql<{ id: string }[]>`
+      SELECT id FROM users WHERE hanablive_username = 'alice'
+    `;
+    const [committeeRole] = await sql<{ id: number }[]>`
+      SELECT id FROM roles WHERE name = 'committee'
+    `;
+    if (!user || !committeeRole) throw new Error('seed data missing');
+
+    await expect(
+      sql`INSERT INTO user_role_assignments (user_id, role_id, source)
+          VALUES (${user.id}, ${committeeRole.id}, 'admin_api')`,
+    ).rejects.toThrow();
+  });
+
+  // ── rollback ─────────────────────────────────────────────────────────────────
+
+  it('down migration drops users and user_role_assignments', async () => {
+    await sql.unsafe(downUsers);
+
+    for (const table of ['user_role_assignments', 'users']) {
+      const [row] = await sql<{ exists: boolean }[]>`
+        SELECT EXISTS (
+          SELECT 1 FROM information_schema.tables
+          WHERE table_schema = 'tracker' AND table_name = ${table}
+        ) AS exists
+      `;
+      expect(row?.exists, `${table} should not exist after rollback`).toBe(false);
+    }
+
+    // Lookup tables should still be present.
+    const [row] = await sql<{ exists: boolean }[]>`
+      SELECT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'tracker' AND table_name = 'roles'
+      ) AS exists
+    `;
+    expect(row?.exists).toBe(true);
+
+    // Clean up the rest for afterAll.
+    await sql.unsafe(downLookup);
+  });
+});

--- a/tracker/types/src/tickets.ts
+++ b/tracker/types/src/tickets.ts
@@ -1,27 +1,26 @@
-/** Ticket type slugs. */
-export type TicketTypeSlug = 'bug' | 'idea' | 'feedback';
+/** Ticket type slugs — must match ticket_types seed data. */
+export type TicketTypeSlug = 'bug' | 'feature_request' | 'question' | 'feedback' | 'other';
 
-/** Domain slugs. */
+/** Domain slugs — must match domains seed data. */
 export type DomainSlug =
-  | 'site_and_ui'
-  | 'competition_rules'
-  | 'content_and_docs'
-  | 'community_and_moderation'
-  | 'infrastructure';
+  | 'gameplay'
+  | 'scoring'
+  | 'registration'
+  | 'interface'
+  | 'matchmaking'
+  | 'events'
+  | 'discord'
+  | 'other';
 
-/** Status slugs. */
+/** Status slugs — must match statuses seed data. */
 export type StatusSlug =
   | 'submitted'
-  | 'needs_clarification'
-  | 'in_triage'
-  | 'open'
-  | 'planned'
-  | 'in_progress'
-  | 'shipped'
-  | 'declined'
-  | 'noted'
-  | 'duplicate'
-  | 'abandoned';
+  | 'triaged'
+  | 'in_review'
+  | 'decided'
+  | 'resolved'
+  | 'rejected'
+  | 'closed';
 
 /** Severity levels for bug tickets. */
 export type BugSeverity = 'cosmetic' | 'functional' | 'blocking';

--- a/tracker/types/src/users.ts
+++ b/tracker/types/src/users.ts
@@ -1,8 +1,17 @@
-/** Role slugs. */
+/** Role slugs — must match roles seed data. */
 export type RoleSlug = 'community_member' | 'moderator' | 'committee';
 
-/** Account status values. */
+/** Account status values — must match users.account_status check constraint. */
 export type AccountStatus = 'active' | 'restricted' | 'banned';
 
-/** Assignment source. */
+/** Assignment source — must match user_role_assignments.source check constraint. */
 export type AssignmentSource = 'manual' | 'discord_sync';
+
+/** A tracker user as resolved by the auth middleware. */
+export interface TrackerUser {
+  id: string;
+  hanablive_username: string;
+  display_name: string;
+  account_status: AccountStatus;
+  role: RoleSlug;
+}


### PR DESCRIPTION
## Summary

Creates the tracker user identity and role assignment tables. Also corrects slug type definitions in \`@tracker/types\` that were stale placeholders, and fixes a test isolation bug where migration SQL was running in the \`public\` schema instead of \`tracker\`.

## Design Decisions

**No explicit community_member assignments:** The \`user_role_assignments\` table stores only elevated role grants (moderator, committee). The \`community_member\` role is the implicit default resolved by the middleware when no active elevated assignment exists. Storing community_member would add rows with no semantic value.

**Partial unique index for active assignments:** \`UNIQUE (user_id, role_id) WHERE revoked_at IS NULL\` prevents duplicate active assignments while preserving full revocation history. A regular unique constraint would prevent reassignment after revocation.

**source column for discord_sync provenance:** Role grants can originate from manual committee action or from Discord role sync. Recording the source is essential for audit trail and for the Discord bot's re-grant logic on \`/token\`.

**search_path fix in migration tests:** Tests were creating tables in \`public\` instead of \`tracker\` because the postgres.js client was using the default search_path. Fixed by adding \`connection: { search_path: 'tracker' }\` to the client constructor in migration test files. This applies to every connection in the pool (unlike a one-time SET command). The core_lookup_tables test gets the same fix retroactively.

**Slug type corrections:** \`TicketTypeSlug\`, \`DomainSlug\`, and \`StatusSlug\` in \`tracker/types\` were draft placeholders that didn't match migration 004's seed data. Corrected here since downstream code (middleware, routes) will import these types in later tickets.

## Verification Steps

```bash
TRACKER_DATABASE_URL=postgresql://... TRACKER_TEST_DATABASE_URL=postgresql://... pnpm tracker:test:integration
pnpm tracker:db:migrate   # apply to local dev DB
pnpm tracker:db:rollback  # verify down migration
```

## Test Coverage

- Creates a user and reads it back
- Rejects duplicate hanablive_username
- Rejects invalid account_status (CHECK constraint)
- Assigns a role and verifies defaults
- Rejects duplicate active role assignment (partial unique index)
- Allows reassignment after revocation
- Rejects invalid source value (CHECK constraint)
- Down migration drops both tables while leaving lookup tables intact

## Follow-On Notes

- TICKET 006 (tickets table) references users.id as the submitter FK
- The \`resolveTrackerRole\` middleware (later ticket) queries \`user_role_assignments WHERE revoked_at IS NULL\` and returns \`community_member\` as the default when no row exists
- \`updated_at\` on users is not auto-updated by a trigger — the upsert query in the auth middleware must set it explicitly on each request