### PR TITLE
migration(tracker): notification tables (#009)

### DIFF
--- a/tracker/server/migrations/20260327200000_notifications.sql
+++ b/tracker/server/migrations/20260327200000_notifications.sql
@@ -1,0 +1,46 @@
+-- Up Migration
+
+-- Tracks which users are subscribed to a ticket.
+-- Users are auto-subscribed by the service layer on ticket creation,
+-- comment, and vote. Explicit subscribe/unsubscribe is also supported.
+CREATE TABLE ticket_subscriptions (
+  ticket_id  UUID        NOT NULL REFERENCES tickets (id),
+  user_id    UUID        NOT NULL REFERENCES users (id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (ticket_id, user_id)
+);
+
+-- One row per event that triggers notification fanout.
+-- Inserted by the lifecycle engine and the discussion service.
+CREATE TABLE notification_events (
+  id         UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+  ticket_id  UUID        NOT NULL REFERENCES tickets (id),
+  -- Discriminator: 'status_changed', 'comment_added'
+  event_type TEXT        NOT NULL,
+  actor_id   UUID        NOT NULL REFERENCES users (id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_notification_events_ticket_id
+  ON notification_events (ticket_id, created_at DESC);
+
+-- One row per subscriber per event. The actor is excluded from fanout.
+CREATE TABLE user_notifications (
+  id         UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID        NOT NULL REFERENCES users (id),
+  event_id   UUID        NOT NULL REFERENCES notification_events (id),
+  is_read    BOOLEAN     NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, event_id)
+);
+
+CREATE INDEX idx_user_notifications_user_id
+  ON user_notifications (user_id, is_read, created_at DESC);
+
+-- Down Migration
+
+DROP INDEX idx_user_notifications_user_id;
+DROP TABLE user_notifications;
+DROP INDEX idx_notification_events_ticket_id;
+DROP TABLE notification_events;
+DROP TABLE ticket_subscriptions;

--- a/tracker/server/tests/integration/migrations/notifications.test.ts
+++ b/tracker/server/tests/integration/migrations/notifications.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import postgres from 'postgres';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { getTestDatabaseUrl, setupTestSchema, teardownTestSchema } from '../../support/db.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function parseMigration(filePath: string): { up: string; down: string } {
+  const content = readFileSync(filePath, 'utf8');
+  const [upRaw, downRaw] = content.split('-- Down Migration');
+  if (!upRaw || !downRaw) throw new Error('Migration missing Up or Down section');
+  return {
+    up: upRaw.replace('-- Up Migration', '').trim(),
+    down: downRaw.trim(),
+  };
+}
+
+const testDbUrl = getTestDatabaseUrl();
+const migrationsDir = join(__dirname, '../../../migrations');
+
+const migrations = [
+  '20260327000000_core_lookup_tables.sql',
+  '20260327120000_users.sql',
+  '20260327140000_tickets.sql',
+  '20260327160000_lifecycle.sql',
+  '20260327180000_discussion.sql',
+  '20260327200000_notifications.sql',
+].map((f) => parseMigration(join(migrationsDir, f)));
+
+describe('migration: 20260327200000_notifications', () => {
+  let sql: postgres.Sql;
+  let ticketId: string;
+  let userId: string;
+  let userId2: string;
+  let eventId: string;
+
+  beforeAll(async () => {
+    sql = postgres(testDbUrl, { max: 2, connection: { search_path: 'tracker' } });
+    await setupTestSchema(sql);
+    for (const { up } of migrations) {
+      await sql.unsafe(up);
+    }
+
+    const [submitted] = await sql<{ id: number }[]>`
+      SELECT id FROM statuses WHERE slug = 'submitted'
+    `;
+    const [bugType] = await sql<{ id: number }[]>`
+      SELECT id FROM ticket_types WHERE slug = 'bug'
+    `;
+    const [gameplay] = await sql<{ id: number }[]>`
+      SELECT id FROM domains WHERE slug = 'gameplay'
+    `;
+    if (!submitted || !bugType || !gameplay) throw new Error('seed data missing');
+
+    const [u1] = await sql<{ id: string }[]>`
+      INSERT INTO users (hanablive_username, display_name) VALUES ('alice', 'Alice') RETURNING id
+    `;
+    const [u2] = await sql<{ id: string }[]>`
+      INSERT INTO users (hanablive_username, display_name) VALUES ('bob', 'Bob') RETURNING id
+    `;
+    if (!u1 || !u2) throw new Error('user insert failed');
+    userId = u1.id;
+    userId2 = u2.id;
+
+    const [ticket] = await sql<{ id: string }[]>`
+      INSERT INTO tickets (title, description, type_id, domain_id, submitted_by, current_status_id)
+      VALUES ('Test', 'desc', ${bugType.id}, ${gameplay.id}, ${userId}, ${submitted.id})
+      RETURNING id
+    `;
+    if (!ticket) throw new Error('ticket insert failed');
+    ticketId = ticket.id;
+  });
+
+  afterAll(async () => {
+    await teardownTestSchema(sql);
+    await sql.end();
+  });
+
+  // ── ticket_subscriptions ─────────────────────────────────────────────────────
+
+  it('subscribes a user to a ticket', async () => {
+    await sql`
+      INSERT INTO ticket_subscriptions (ticket_id, user_id) VALUES (${ticketId}, ${userId})
+    `;
+    const [row] = await sql<{ count: string }[]>`
+      SELECT count(*) FROM ticket_subscriptions WHERE ticket_id = ${ticketId}
+    `;
+    expect(Number(row?.count)).toBe(1);
+  });
+
+  it('rejects a duplicate subscription', async () => {
+    await expect(
+      sql`INSERT INTO ticket_subscriptions (ticket_id, user_id) VALUES (${ticketId}, ${userId})`,
+    ).rejects.toThrow();
+  });
+
+  // ── notification_events ──────────────────────────────────────────────────────
+
+  it('inserts a notification event', async () => {
+    const [event] = await sql<{ id: string }[]>`
+      INSERT INTO notification_events (ticket_id, event_type, actor_id)
+      VALUES (${ticketId}, 'status_changed', ${userId})
+      RETURNING id
+    `;
+    expect(event?.id).toBeDefined();
+    if (!event) throw new Error('event insert failed');
+    eventId = event.id;
+  });
+
+  // ── user_notifications ───────────────────────────────────────────────────────
+
+  it('delivers a notification to a subscriber', async () => {
+    await sql`
+      INSERT INTO user_notifications (user_id, event_id) VALUES (${userId2}, ${eventId})
+    `;
+    const [row] = await sql<{ is_read: boolean }[]>`
+      SELECT is_read FROM user_notifications WHERE user_id = ${userId2} AND event_id = ${eventId}
+    `;
+    expect(row?.is_read).toBe(false);
+  });
+
+  it('rejects a duplicate user_notification for the same event', async () => {
+    await expect(
+      sql`INSERT INTO user_notifications (user_id, event_id) VALUES (${userId2}, ${eventId})`,
+    ).rejects.toThrow();
+  });
+
+  it('marks a notification as read', async () => {
+    await sql`
+      UPDATE user_notifications SET is_read = TRUE
+      WHERE user_id = ${userId2} AND event_id = ${eventId}
+    `;
+    const [row] = await sql<{ is_read: boolean }[]>`
+      SELECT is_read FROM user_notifications WHERE user_id = ${userId2} AND event_id = ${eventId}
+    `;
+    expect(row?.is_read).toBe(true);
+  });
+
+  // ── rollback ─────────────────────────────────────────────────────────────────
+
+  it('down migration drops all three notification tables', async () => {
+    const { down } = migrations[5]!;
+    await sql.unsafe(down);
+
+    for (const table of ['user_notifications', 'notification_events', 'ticket_subscriptions']) {
+      const [row] = await sql<{ exists: boolean }[]>`
+        SELECT EXISTS (
+          SELECT 1 FROM information_schema.tables
+          WHERE table_schema = 'tracker' AND table_name = ${table}
+        ) AS exists
+      `;
+      expect(row?.exists, `${table} should not exist after rollback`).toBe(false);
+    }
+
+    for (const { down: d } of [...migrations].reverse().slice(1)) {
+      await sql.unsafe(d);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Creates the three-table notification system: subscriptions, events, and per-user notification rows. Together with the lifecycle engine and discussion service (later tickets), these power the fanout described in the architecture.

## Design Decisions

**Three-table fanout model:** Separating notification_events (one per triggering action) from user_notifications (one per subscriber per action) allows efficient "unread count" and "mark all read" queries without scanning the events table per user.

**event_type as TEXT:** A CHECK constraint was omitted intentionally — new event types should be addable without a schema migration. The valid values ('status_changed', 'comment_added') are enforced at the service layer.

**Actor excluded at service layer:** The user_notifications table has no actor exclusion constraint; it's enforced in the notification service. A DB constraint would require a JOIN to notification_events on every insert, adding complexity without meaningful safety gain.

**UNIQUE (user_id, event_id) on user_notifications:** Prevents duplicate delivery if the fanout service runs twice (e.g., retry on error).

## Verification Steps

```bash
TRACKER_DATABASE_URL=... TRACKER_TEST_DATABASE_URL=... pnpm tracker:test:integration
pnpm tracker:db:migrate && pnpm tracker:db:rollback
```

## Test Coverage

- Subscribe a user; reject duplicate subscription
- Insert a notification event
- Deliver to a subscriber; reject duplicate delivery
- Mark a notification as read
- Down migration drops all three tables

## Follow-On Notes

- TICKET 010 (integrations): adds discord_delivery_log and discord_role_sync_log
- The notification service implementation (later ticket) must exclude the actor when inserting user_notifications rows
- The Discord outbound webhook fires after the notification_events transaction commits (fire-and-forget); delivery failures go to discord_delivery_log, not here