### PR TITLE
feat(tracker): auth middleware and DB user helpers (TICKET-012)

### DIFF
--- a/tracker/server/src/db/pool.ts
+++ b/tracker/server/src/db/pool.ts
@@ -16,6 +16,7 @@ export function getPool(): postgres.Sql {
       ssl: env.TRACKER_DATABASE_SSL ? 'require' : false,
       connection: {
         application_name: 'tracker',
+        search_path: 'tracker',
       },
       // Crash the process on connection error at startup — do not swallow silently
       onnotice: () => undefined,

--- a/tracker/server/src/db/users.ts
+++ b/tracker/server/src/db/users.ts
@@ -1,0 +1,50 @@
+import type { Sql } from 'postgres';
+import type { AccountStatus, RoleSlug } from '@tracker/types';
+
+export interface TrackerUserRow {
+  id: string;
+  hanablive_username: string;
+  display_name: string;
+  account_status: AccountStatus;
+}
+
+/**
+ * Inserts a user on first access; updates display_name on subsequent requests.
+ * Uses ON CONFLICT to make the operation idempotent.
+ */
+export async function upsertTrackerUser(
+  sql: Sql,
+  hanabLiveUsername: string,
+  displayName: string,
+): Promise<TrackerUserRow> {
+  const rows = await sql<TrackerUserRow[]>`
+    INSERT INTO users (hanablive_username, display_name)
+    VALUES (${hanabLiveUsername}, ${displayName})
+    ON CONFLICT (hanablive_username)
+    DO UPDATE SET
+      display_name = EXCLUDED.display_name,
+      updated_at   = now()
+    RETURNING id, hanablive_username, display_name, account_status
+  `;
+  const row = rows[0];
+  if (!row) throw new Error('upsertTrackerUser: no row returned');
+  return row;
+}
+
+/**
+ * Returns the highest-privilege active role for the given user.
+ * Defaults to 'community_member' when no explicit assignment exists.
+ * Priority: committee > moderator > community_member.
+ */
+export async function resolveUserRole(sql: Sql, userId: string): Promise<RoleSlug> {
+  const rows = await sql<{ name: string }[]>`
+    SELECT r.name
+    FROM user_role_assignments ura
+    JOIN roles r ON r.id = ura.role_id
+    WHERE ura.user_id = ${userId}
+      AND ura.revoked_at IS NULL
+  `;
+  if (rows.some((r) => r.name === 'committee')) return 'committee';
+  if (rows.some((r) => r.name === 'moderator')) return 'moderator';
+  return 'community_member';
+}

--- a/tracker/server/src/middleware/auth.ts
+++ b/tracker/server/src/middleware/auth.ts
@@ -1,0 +1,133 @@
+import { type Request, type Response, type NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+import type { TrackerUser, TrackerErrorResponse } from '@tracker/types';
+import { getPool } from '../db/pool.js';
+import { upsertTrackerUser, resolveUserRole } from '../db/users.js';
+
+/**
+ * Shape of req.user as attached by the main site's auth middleware.
+ * The tracker only reads hanabLiveUsername and, optionally, displayName.
+ */
+interface SiteUser {
+  hanabLiveUsername?: string;
+  displayName?: string;
+}
+
+/**
+ * Extended request type after requireTrackerAuth has run.
+ * Use this type in route handlers that sit behind requireTrackerAuth.
+ */
+export interface AuthenticatedRequest extends Request {
+  trackerUser: TrackerUser;
+  correlationId: string;
+}
+
+/**
+ * Per-role permission sets. Must stay in sync with the seed data in
+ * migration 20260327000000_core_lookup_tables.sql.
+ */
+const ROLE_PERMISSIONS: Record<string, ReadonlySet<string>> = {
+  community_member: new Set(['ticket.create', 'ticket.comment', 'ticket.vote']),
+  moderator: new Set([
+    'ticket.create',
+    'ticket.comment',
+    'ticket.vote',
+    'ticket.triage',
+    'ticket.transition',
+    'ticket.view_internal',
+  ]),
+  committee: new Set([
+    'ticket.create',
+    'ticket.comment',
+    'ticket.vote',
+    'ticket.triage',
+    'ticket.transition',
+    'ticket.view_internal',
+    'ticket.decide',
+    'user.role.assign',
+  ]),
+};
+
+function correlationId(req: Request): string {
+  return (req as Partial<AuthenticatedRequest>).correlationId ?? randomUUID();
+}
+
+function errorResponse(code: string, message: string, req: Request): TrackerErrorResponse {
+  return { error: { code, message, correlationId: correlationId(req) } };
+}
+
+/**
+ * Reads the hanab.live username from the existing site session, upserts
+ * the tracker user record, resolves the role, and attaches req.trackerUser.
+ *
+ * Returns 401 if no authenticated session is present.
+ * Returns 403 if the account_status is 'banned' or 'restricted'.
+ */
+export async function requireTrackerAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  const siteUser = (req as Request & { user?: SiteUser }).user;
+  const hanabLiveUsername = siteUser?.hanabLiveUsername;
+
+  if (!hanabLiveUsername) {
+    res.status(401).json(errorResponse('UNAUTHORIZED', 'Authentication required.', req));
+    return;
+  }
+
+  const displayName = siteUser.displayName ?? hanabLiveUsername;
+
+  try {
+    const sql = getPool();
+    const user = await upsertTrackerUser(sql, hanabLiveUsername, displayName);
+
+    if (user.account_status === 'banned' || user.account_status === 'restricted') {
+      res
+        .status(403)
+        .json(errorResponse('FORBIDDEN', 'Your account does not have access to the tracker.', req));
+      return;
+    }
+
+    const role = await resolveUserRole(sql, user.id);
+
+    (req as AuthenticatedRequest).trackerUser = {
+      id: user.id,
+      hanablive_username: user.hanablive_username,
+      display_name: user.display_name,
+      account_status: user.account_status,
+      role,
+    };
+
+    next();
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * Middleware factory. Returns a middleware that checks whether
+ * req.trackerUser has the given permission.
+ *
+ * Must be used after requireTrackerAuth in the middleware chain.
+ */
+export function requirePermission(
+  action: string,
+): (req: Request, res: Response, next: NextFunction) => void {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const trackerUser = (req as Partial<AuthenticatedRequest>).trackerUser;
+
+    if (!trackerUser) {
+      res.status(401).json(errorResponse('UNAUTHORIZED', 'Authentication required.', req));
+      return;
+    }
+
+    const allowed = ROLE_PERMISSIONS[trackerUser.role];
+    if (!allowed?.has(action)) {
+      res.status(403).json(errorResponse('FORBIDDEN', `Permission denied: ${action}.`, req));
+      return;
+    }
+
+    next();
+  };
+}

--- a/tracker/server/tests/unit/middleware/auth.test.ts
+++ b/tracker/server/tests/unit/middleware/auth.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response, NextFunction } from 'express';
+import type { Sql } from 'postgres';
+import type { TrackerUserRow } from '../../../src/db/users.js';
+import type { RoleSlug, TrackerUser } from '@tracker/types';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockSql = {} as Sql;
+
+vi.mock('../../../src/db/pool.js', () => ({
+  getPool: vi.fn(() => mockSql),
+}));
+
+const mockUpsertTrackerUser = vi.fn<() => Promise<TrackerUserRow>>();
+const mockResolveUserRole = vi.fn<() => Promise<RoleSlug>>();
+
+vi.mock('../../../src/db/users.js', () => ({
+  upsertTrackerUser: mockUpsertTrackerUser,
+  resolveUserRole: mockResolveUserRole,
+}));
+
+// ── Import after mocks ────────────────────────────────────────────────────────
+
+const { requireTrackerAuth, requirePermission } = await import('../../../src/middleware/auth.js');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(user?: { hanabLiveUsername?: string; displayName?: string }): Request {
+  return { user } as unknown as Request;
+}
+
+interface MockRes {
+  _status: number;
+  _body: unknown;
+  status: (code: number) => this;
+  json: (body: unknown) => this;
+}
+
+function makeRes(): MockRes & Response {
+  const res: MockRes = {
+    _status: 0,
+    _body: undefined,
+    status(code: number) {
+      this._status = code;
+      return this;
+    },
+    json(body: unknown) {
+      this._body = body;
+      return this;
+    },
+  };
+  return res as unknown as MockRes & Response;
+}
+
+interface MockNext extends NextFunction {
+  error: unknown;
+  called: boolean;
+}
+
+function makeNext(): MockNext {
+  const fn = vi.fn((err?: unknown) => {
+    fn.error = err;
+    fn.called = true;
+  }) as unknown as MockNext;
+  fn.error = undefined;
+  fn.called = false;
+  return fn;
+}
+
+function errorCode(res: MockRes & Response): string {
+  return (res._body as { error: { code: string } }).error.code;
+}
+
+// ── requireTrackerAuth ────────────────────────────────────────────────────────
+
+describe('requireTrackerAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when no req.user is set', async () => {
+    const req = makeReq(undefined);
+    const res = makeRes();
+    const next = makeNext();
+
+    await requireTrackerAuth(req, res, next);
+
+    expect(res._status).toBe(401);
+    expect(errorCode(res)).toBe('UNAUTHORIZED');
+    expect(next.called).toBe(false);
+  });
+
+  it('returns 401 when hanabLiveUsername is missing', async () => {
+    const req = makeReq({});
+    const res = makeRes();
+    const next = makeNext();
+
+    await requireTrackerAuth(req, res, next);
+
+    expect(res._status).toBe(401);
+    expect(errorCode(res)).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 403 when account_status is banned', async () => {
+    mockUpsertTrackerUser.mockResolvedValue({
+      id: 'user-1',
+      hanablive_username: 'alice',
+      display_name: 'Alice',
+      account_status: 'banned',
+    });
+
+    const req = makeReq({ hanabLiveUsername: 'alice' });
+    const res = makeRes();
+    const next = makeNext();
+
+    await requireTrackerAuth(req, res, next);
+
+    expect(res._status).toBe(403);
+    expect(errorCode(res)).toBe('FORBIDDEN');
+    expect(next.called).toBe(false);
+  });
+
+  it('returns 403 when account_status is restricted', async () => {
+    mockUpsertTrackerUser.mockResolvedValue({
+      id: 'user-1',
+      hanablive_username: 'bob',
+      display_name: 'Bob',
+      account_status: 'restricted',
+    });
+
+    const req = makeReq({ hanabLiveUsername: 'bob' });
+    const res = makeRes();
+    const next = makeNext();
+
+    await requireTrackerAuth(req, res, next);
+
+    expect(res._status).toBe(403);
+    expect(errorCode(res)).toBe('FORBIDDEN');
+  });
+
+  it('attaches trackerUser and calls next() for an active community_member', async () => {
+    mockUpsertTrackerUser.mockResolvedValue({
+      id: 'user-2',
+      hanablive_username: 'carol',
+      display_name: 'Carol',
+      account_status: 'active',
+    });
+    mockResolveUserRole.mockResolvedValue('community_member');
+
+    const req = makeReq({ hanabLiveUsername: 'carol', displayName: 'Carol' });
+    const res = makeRes();
+    const next = makeNext();
+
+    await requireTrackerAuth(req, res, next);
+
+    expect(next.error).toBeUndefined();
+    const trackerUser = (req as unknown as Record<string, unknown>).trackerUser as TrackerUser;
+    expect(trackerUser.id).toBe('user-2');
+    expect(trackerUser.role).toBe('community_member');
+    expect(trackerUser.account_status).toBe('active');
+  });
+
+  it('uses hanabLiveUsername as displayName fallback when displayName is absent', async () => {
+    mockUpsertTrackerUser.mockResolvedValue({
+      id: 'user-3',
+      hanablive_username: 'dave',
+      display_name: 'dave',
+      account_status: 'active',
+    });
+    mockResolveUserRole.mockResolvedValue('community_member');
+
+    const req = makeReq({ hanabLiveUsername: 'dave' });
+    const res = makeRes();
+    const next = makeNext();
+
+    await requireTrackerAuth(req, res, next);
+
+    expect(mockUpsertTrackerUser).toHaveBeenCalledWith(mockSql, 'dave', 'dave');
+  });
+
+  it('calls next(err) when DB throws', async () => {
+    const boom = new Error('db error');
+    mockUpsertTrackerUser.mockRejectedValue(boom);
+
+    const req = makeReq({ hanabLiveUsername: 'eve' });
+    const res = makeRes();
+    const next = makeNext();
+
+    await requireTrackerAuth(req, res, next);
+
+    expect(next.error).toBe(boom);
+  });
+});
+
+// ── requirePermission ─────────────────────────────────────────────────────────
+
+describe('requirePermission', () => {
+  function reqWithRole(role?: RoleSlug): Request {
+    const req = {} as unknown as Record<string, unknown>;
+    if (role !== undefined) {
+      req.trackerUser = {
+        id: 'u',
+        hanablive_username: 'x',
+        display_name: 'X',
+        account_status: 'active',
+        role,
+      } satisfies TrackerUser;
+    }
+    return req as unknown as Request;
+  }
+
+  it('returns 401 when no trackerUser is attached', () => {
+    const req = reqWithRole();
+    const res = makeRes();
+    const next = makeNext();
+
+    requirePermission('ticket.create')(req, res, next);
+
+    expect(res._status).toBe(401);
+    expect(errorCode(res)).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 403 when role lacks the permission', () => {
+    const req = reqWithRole('community_member');
+    const res = makeRes();
+    const next = makeNext();
+
+    requirePermission('ticket.triage')(req, res, next);
+
+    expect(res._status).toBe(403);
+    expect(errorCode(res)).toBe('FORBIDDEN');
+  });
+
+  it('calls next() when community_member has ticket.create', () => {
+    const req = reqWithRole('community_member');
+    const res = makeRes();
+    const next = makeNext();
+
+    requirePermission('ticket.create')(req, res, next);
+
+    expect(next.error).toBeUndefined();
+    expect(res._status).toBe(0);
+  });
+
+  it('calls next() when moderator has ticket.triage', () => {
+    const req = reqWithRole('moderator');
+    const res = makeRes();
+    const next = makeNext();
+
+    requirePermission('ticket.triage')(req, res, next);
+
+    expect(next.error).toBeUndefined();
+  });
+
+  it('calls next() when committee has ticket.decide', () => {
+    const req = reqWithRole('committee');
+    const res = makeRes();
+    const next = makeNext();
+
+    requirePermission('ticket.decide')(req, res, next);
+
+    expect(next.error).toBeUndefined();
+  });
+
+  it('returns 403 when moderator lacks ticket.decide', () => {
+    const req = reqWithRole('moderator');
+    const res = makeRes();
+    const next = makeNext();
+
+    requirePermission('ticket.decide')(req, res, next);
+
+    expect(res._status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `search_path: 'tracker'` to the pool connection options so all app-layer queries run in the right schema
- Adds `upsertTrackerUser` and `resolveUserRole` query helpers in `db/users.ts`
- Adds `requireTrackerAuth` middleware (upserts user, checks account status, resolves role, attaches `req.trackerUser`)
- Adds `requirePermission(action)` middleware factory (in-memory role→permission map mirroring migration 004 seed)
- Full unit test coverage for all 401/403/next paths and per-role permission checks

## Test plan
- [ ] All CI jobs pass (typecheck, lint, build, unit-tests, integration-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)