### PR TITLE
feat(tracker): ticket DB queries, lifecycle service, and REST routes (TICKET-013)

### DIFF
--- a/tracker/server/src/app.ts
+++ b/tracker/server/src/app.ts
@@ -2,6 +2,7 @@ import express, { type Request, type Response, type NextFunction } from 'express
 import { randomUUID } from 'crypto';
 import type { HealthResponse, TrackerErrorResponse } from '@tracker/types';
 import { checkDbHealth } from './db/pool.js';
+import { ticketsRouter } from './routes/tickets.js';
 
 export function createApp() {
   const app = express();
@@ -13,6 +14,9 @@ export function createApp() {
     (req as Request & { correlationId: string }).correlationId = randomUUID();
     next();
   });
+
+  // API routes
+  app.use('/tracker/api/tickets', ticketsRouter);
 
   // Health checks — no auth required
   app.get('/tracker/health', (_req: Request, res: Response) => {

--- a/tracker/server/src/db/tickets.ts
+++ b/tracker/server/src/db/tickets.ts
@@ -1,0 +1,134 @@
+import type { Sql } from 'postgres';
+import type {
+  TicketTypeSlug,
+  DomainSlug,
+  StatusSlug,
+  BugSeverity,
+  BugReproducibility,
+  TicketSummary,
+  TicketDetail,
+} from '@tracker/types';
+
+export interface CreateTicketInput {
+  title: string;
+  description: string;
+  type_id: number;
+  domain_id: number;
+  severity?: BugSeverity;
+  reproducibility?: BugReproducibility;
+}
+
+export interface TicketRow {
+  id: string;
+  current_status_id: number;
+}
+
+/** Inserts a ticket row and returns id + current_status_id. */
+export async function insertTicket(
+  sql: Sql,
+  submittedBy: string,
+  currentStatusId: number,
+  input: CreateTicketInput,
+): Promise<TicketRow> {
+  const rows = await sql<TicketRow[]>`
+    INSERT INTO tickets (title, description, type_id, domain_id, submitted_by, current_status_id, severity, reproducibility)
+    VALUES (
+      ${input.title},
+      ${input.description},
+      ${input.type_id},
+      ${input.domain_id},
+      ${submittedBy},
+      ${currentStatusId},
+      ${input.severity ?? null},
+      ${input.reproducibility ?? null}
+    )
+    RETURNING id, current_status_id
+  `;
+  const row = rows[0];
+  if (!row) throw new Error('insertTicket: no row returned');
+  return row;
+}
+
+interface TicketSummaryRow {
+  id: string;
+  title: string;
+  type_slug: TicketTypeSlug;
+  domain_slug: DomainSlug;
+  status_slug: StatusSlug;
+  is_terminal: boolean;
+  submitted_by_display_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TicketDetailRow extends TicketSummaryRow {
+  description: string;
+  severity: BugSeverity | null;
+  reproducibility: BugReproducibility | null;
+}
+
+/** Returns a paginated list of tickets ordered by newest first. */
+export async function listTickets(
+  sql: Sql,
+  opts: { limit: number; offset: number },
+): Promise<{ tickets: TicketSummary[]; total: number }> {
+  const [countRow] = await sql<{ count: string }[]>`SELECT COUNT(*)::TEXT AS count FROM tickets`;
+  const total = parseInt(countRow?.count ?? '0', 10);
+
+  const rows = await sql<TicketSummaryRow[]>`
+    SELECT
+      t.id,
+      t.title,
+      tt.slug        AS type_slug,
+      d.slug         AS domain_slug,
+      s.slug         AS status_slug,
+      s.is_terminal,
+      u.display_name AS submitted_by_display_name,
+      t.created_at::TEXT AS created_at,
+      t.updated_at::TEXT AS updated_at
+    FROM tickets t
+    JOIN ticket_types tt ON tt.id = t.type_id
+    JOIN domains       d  ON d.id  = t.domain_id
+    JOIN statuses      s  ON s.id  = t.current_status_id
+    JOIN users         u  ON u.id  = t.submitted_by
+    ORDER BY t.created_at DESC
+    LIMIT  ${opts.limit}
+    OFFSET ${opts.offset}
+  `;
+
+  return { tickets: rows, total };
+}
+
+/** Returns a single ticket with full detail, or null if not found. */
+export async function getTicketById(sql: Sql, id: string): Promise<TicketDetail | null> {
+  const rows = await sql<TicketDetailRow[]>`
+    SELECT
+      t.id,
+      t.title,
+      t.description,
+      tt.slug        AS type_slug,
+      d.slug         AS domain_slug,
+      s.slug         AS status_slug,
+      s.is_terminal,
+      u.display_name AS submitted_by_display_name,
+      t.severity,
+      t.reproducibility,
+      t.created_at::TEXT AS created_at,
+      t.updated_at::TEXT AS updated_at
+    FROM tickets t
+    JOIN ticket_types tt ON tt.id = t.type_id
+    JOIN domains       d  ON d.id  = t.domain_id
+    JOIN statuses      s  ON s.id  = t.current_status_id
+    JOIN users         u  ON u.id  = t.submitted_by
+    WHERE t.id = ${id}
+  `;
+  return rows[0] ?? null;
+}
+
+/** Looks up a status id by slug. Throws if not found. */
+export async function getStatusId(sql: Sql, slug: string): Promise<number> {
+  const rows = await sql<{ id: number }[]>`SELECT id FROM statuses WHERE slug = ${slug}`;
+  const row = rows[0];
+  if (!row) throw new Error(`getStatusId: no status with slug '${slug}'`);
+  return row.id;
+}

--- a/tracker/server/src/routes/tickets.ts
+++ b/tracker/server/src/routes/tickets.ts
@@ -1,0 +1,123 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import type {
+  CreateTicketRequest,
+  CreateTicketResponse,
+  ListTicketsResponse,
+  GetTicketResponse,
+} from '@tracker/types';
+import { getPool } from '../db/pool.js';
+import { listTickets, getTicketById } from '../db/tickets.js';
+import { submitTicket } from '../services/lifecycle.js';
+import {
+  requireTrackerAuth,
+  requirePermission,
+  type AuthenticatedRequest,
+} from '../middleware/auth.js';
+
+const router = Router();
+
+/** POST /tracker/api/tickets — submit a new ticket */
+router.post(
+  '/',
+  requireTrackerAuth,
+  requirePermission('ticket.create'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const body = req.body as CreateTicketRequest;
+    const { title, description, type_id, domain_id, severity, reproducibility } = body;
+
+    if (
+      typeof title !== 'string' ||
+      !title.trim() ||
+      typeof description !== 'string' ||
+      !description.trim() ||
+      typeof type_id !== 'number' ||
+      typeof domain_id !== 'number'
+    ) {
+      res.status(422).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'title, description, type_id, and domain_id are required.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const sql = getPool();
+      const result = await submitTicket(sql, (req as AuthenticatedRequest).trackerUser.id, {
+        title: title.trim(),
+        description: description.trim(),
+        type_id,
+        domain_id,
+        ...(severity !== undefined && { severity }),
+        ...(reproducibility !== undefined && { reproducibility }),
+      });
+      const body2: CreateTicketResponse = { id: result.id };
+      res.status(201).json(body2);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** GET /tracker/api/tickets — list tickets (paginated) */
+router.get(
+  '/',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const rawLimit = Number(req.query.limit ?? 25);
+    const rawOffset = Number(req.query.offset ?? 0);
+    const limit = Number.isInteger(rawLimit) && rawLimit > 0 && rawLimit <= 100 ? rawLimit : 25;
+    const offset = Number.isInteger(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
+
+    try {
+      const sql = getPool();
+      const { tickets, total } = await listTickets(sql, { limit, offset });
+      const body: ListTicketsResponse = { tickets, total, limit, offset };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** GET /tracker/api/tickets/:id — get a single ticket */
+router.get(
+  '/:id',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const id = req.params['id'] as string | undefined;
+    if (!id) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Ticket not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const sql = getPool();
+      const ticket = await getTicketById(sql, id);
+      if (!ticket) {
+        res.status(404).json({
+          error: {
+            code: 'NOT_FOUND',
+            message: 'Ticket not found.',
+            correlationId: (req as AuthenticatedRequest).correlationId,
+          },
+        });
+        return;
+      }
+      const body: GetTicketResponse = ticket;
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export { router as ticketsRouter };

--- a/tracker/server/src/services/lifecycle.ts
+++ b/tracker/server/src/services/lifecycle.ts
@@ -1,0 +1,115 @@
+import type { Sql } from 'postgres';
+import type { CreateTicketInput } from '../db/tickets.js';
+import { getStatusId } from '../db/tickets.js';
+
+/**
+ * Submits a new ticket.
+ *
+ * This is the ONLY entry point for creating tickets. It:
+ *   1. Resolves the 'submitted' status id
+ *   2. Inserts the ticket row, initial status history, and subscription atomically
+ *      via a single CTE (implicitly one transaction)
+ *
+ * Architecture invariant: no other code path may write to ticket_status_history
+ * or update current_status_id on a ticket.
+ */
+export async function submitTicket(
+  sql: Sql,
+  submittedBy: string,
+  input: CreateTicketInput,
+): Promise<{ id: string }> {
+  const submittedStatusId = await getStatusId(sql, 'submitted');
+
+  const rows = await sql<{ id: string }[]>`
+    WITH inserted AS (
+      INSERT INTO tickets (title, description, type_id, domain_id, submitted_by, current_status_id, severity, reproducibility)
+      VALUES (
+        ${input.title},
+        ${input.description},
+        ${input.type_id},
+        ${input.domain_id},
+        ${submittedBy},
+        ${submittedStatusId},
+        ${input.severity ?? null},
+        ${input.reproducibility ?? null}
+      )
+      RETURNING id
+    ),
+    history AS (
+      INSERT INTO ticket_status_history (ticket_id, from_status_id, to_status_id, changed_by)
+      SELECT id, NULL, ${submittedStatusId}, ${submittedBy} FROM inserted
+    ),
+    subscription AS (
+      INSERT INTO ticket_subscriptions (ticket_id, user_id)
+      SELECT id, ${submittedBy} FROM inserted
+    )
+    SELECT id FROM inserted
+  `;
+
+  const ticket = rows[0];
+  if (!ticket) throw new Error('submitTicket: no row returned');
+  return { id: ticket.id };
+}
+
+/**
+ * Transitions a ticket to a new status.
+ *
+ * Validates that the transition is permitted for the given role before writing.
+ * Records the history entry and updates current_status_id atomically via a CTE.
+ *
+ * Returns { ok: false } if the transition is not valid for this role/state.
+ */
+export async function transitionTicket(
+  sql: Sql,
+  ticketId: string,
+  toStatusSlug: string,
+  changedBy: string,
+  roleSlug: string,
+  resolutionNote?: string,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  type CheckRow = {
+    current_status_id: number;
+    is_terminal: boolean;
+    to_id: number | null;
+    allowed: boolean;
+  };
+
+  // Read current state and validate in one query (no FOR UPDATE — acceptable at this scale)
+  const [row] = await sql<CheckRow[]>`
+    SELECT
+      t.current_status_id,
+      s_from.is_terminal,
+      s_to.id AS to_id,
+      EXISTS (
+        SELECT 1 FROM valid_transitions vt
+        JOIN roles r ON r.id = vt.role_id
+        WHERE vt.from_status_id = t.current_status_id
+          AND vt.to_status_id   = s_to.id
+          AND r.name            = ${roleSlug}
+      ) AS allowed
+    FROM tickets t
+    JOIN statuses s_from ON s_from.id = t.current_status_id
+    LEFT JOIN statuses s_to ON s_to.slug = ${toStatusSlug}
+    WHERE t.id = ${ticketId}
+  `;
+
+  if (!row) return { ok: false, reason: 'ticket_not_found' };
+  if (row.is_terminal) return { ok: false, reason: 'already_terminal' };
+  if (row.to_id === null) return { ok: false, reason: 'invalid_to_status' };
+  if (!row.allowed) return { ok: false, reason: 'transition_not_allowed' };
+
+  const toId = row.to_id;
+  const fromId = row.current_status_id;
+
+  // Apply update and history record in one CTE (atomic)
+  await sql`
+    WITH upd AS (
+      UPDATE tickets SET current_status_id = ${toId}, updated_at = now()
+      WHERE id = ${ticketId}
+    )
+    INSERT INTO ticket_status_history (ticket_id, from_status_id, to_status_id, changed_by, resolution_note)
+    VALUES (${ticketId}, ${fromId}, ${toId}, ${changedBy}, ${resolutionNote ?? null})
+  `;
+
+  return { ok: true };
+}

--- a/tracker/types/src/tickets.ts
+++ b/tracker/types/src/tickets.ts
@@ -42,3 +42,34 @@ export interface CreateTicketRequest {
 export interface CreateTicketResponse {
   id: string;
 }
+
+/** Summary of a ticket as returned in list views. */
+export interface TicketSummary {
+  id: string;
+  title: string;
+  type_slug: TicketTypeSlug;
+  domain_slug: DomainSlug;
+  status_slug: StatusSlug;
+  is_terminal: boolean;
+  submitted_by_display_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Full ticket detail including description. */
+export interface TicketDetail extends TicketSummary {
+  description: string;
+  severity: BugSeverity | null;
+  reproducibility: BugReproducibility | null;
+}
+
+/** Response body for GET /tracker/api/tickets */
+export interface ListTicketsResponse {
+  tickets: TicketSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/** Response body for GET /tracker/api/tickets/:id */
+export type GetTicketResponse = TicketDetail;


### PR DESCRIPTION
## Summary
- Extends `@tracker/types` with `TicketSummary`, `TicketDetail`, `ListTicketsResponse`, `GetTicketResponse`
- Adds `db/tickets.ts`: `insertTicket`, `listTickets`, `getTicketById`, `getStatusId`
- Adds `services/lifecycle.ts`: `submitTicket` (atomic CTE write: ticket + history + subscription) and `transitionTicket` (validates against `valid_transitions`, applies via CTE)
- Adds `routes/tickets.ts`: `POST /tracker/api/tickets`, `GET /tracker/api/tickets`, `GET /tracker/api/tickets/:id`
- Wires tickets router into `app.ts`

## Test plan
- [ ] All CI jobs pass (typecheck, lint, build, unit-tests, integration-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)