### PR TITLE
feat(tracker): discussion routes for comments and votes (TICKET-014)

### DIFF
--- a/tracker/server/src/app.ts
+++ b/tracker/server/src/app.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import type { HealthResponse, TrackerErrorResponse } from '@tracker/types';
 import { checkDbHealth } from './db/pool.js';
 import { ticketsRouter } from './routes/tickets.js';
+import { discussionRouter } from './routes/discussion.js';
 
 export function createApp() {
   const app = express();
@@ -17,6 +18,7 @@ export function createApp() {
 
   // API routes
   app.use('/tracker/api/tickets', ticketsRouter);
+  app.use('/tracker/api/tickets/:ticketId', discussionRouter);
 
   // Health checks — no auth required
   app.get('/tracker/health', (_req: Request, res: Response) => {

--- a/tracker/server/src/db/discussion.ts
+++ b/tracker/server/src/db/discussion.ts
@@ -1,0 +1,111 @@
+import type { Sql } from 'postgres';
+import type { TicketComment, TicketVoteState } from '@tracker/types';
+
+/** Inserts a comment and returns its id. */
+export async function insertComment(
+  sql: Sql,
+  ticketId: string,
+  authorId: string,
+  body: string,
+  isInternal: boolean,
+): Promise<{ id: string }> {
+  const rows = await sql<{ id: string }[]>`
+    INSERT INTO ticket_comments (ticket_id, author_id, body, is_internal)
+    VALUES (${ticketId}, ${authorId}, ${body}, ${isInternal})
+    RETURNING id
+  `;
+  const row = rows[0];
+  if (!row) throw new Error('insertComment: no row returned');
+  return { id: row.id };
+}
+
+interface CommentRow {
+  id: string;
+  ticket_id: string;
+  author_display_name: string;
+  body: string;
+  is_internal: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Lists comments on a ticket.
+ * Internal comments are only returned when includeInternal is true.
+ */
+export async function listComments(
+  sql: Sql,
+  ticketId: string,
+  includeInternal: boolean,
+): Promise<TicketComment[]> {
+  const rows = await sql<CommentRow[]>`
+    SELECT
+      c.id,
+      c.ticket_id,
+      u.display_name AS author_display_name,
+      c.body,
+      c.is_internal,
+      c.created_at::TEXT AS created_at,
+      c.updated_at::TEXT AS updated_at
+    FROM ticket_comments c
+    JOIN users u ON u.id = c.author_id
+    WHERE c.ticket_id = ${ticketId}
+      AND (${includeInternal} OR NOT c.is_internal)
+    ORDER BY c.created_at ASC
+  `;
+  return rows;
+}
+
+interface VoteRow {
+  vote_count: string;
+  user_has_voted: boolean;
+}
+
+/** Returns the vote count and whether the given user has voted. */
+export async function getVoteState(
+  sql: Sql,
+  ticketId: string,
+  userId: string,
+): Promise<TicketVoteState> {
+  const [row] = await sql<VoteRow[]>`
+    SELECT
+      COUNT(*)::TEXT AS vote_count,
+      BOOL_OR(user_id = ${userId}) AS user_has_voted
+    FROM ticket_votes
+    WHERE ticket_id = ${ticketId}
+  `;
+  return {
+    ticket_id: ticketId,
+    vote_count: parseInt(row?.vote_count ?? '0', 10),
+    user_has_voted: row?.user_has_voted ?? false,
+  };
+}
+
+/** Adds a vote. Returns false if the user has already voted (idempotent). */
+export async function addVote(
+  sql: Sql,
+  ticketId: string,
+  userId: string,
+): Promise<{ inserted: boolean }> {
+  const rows = await sql<{ id: string }[]>`
+    INSERT INTO ticket_votes (ticket_id, user_id)
+    VALUES (${ticketId}, ${userId})
+    ON CONFLICT (ticket_id, user_id) DO NOTHING
+    RETURNING ticket_id
+  `;
+  return { inserted: rows.length > 0 };
+}
+
+/** Removes a vote. Returns false if the user had not voted. */
+export async function removeVote(
+  sql: Sql,
+  ticketId: string,
+  userId: string,
+): Promise<{ deleted: boolean }> {
+  const rows = await sql<{ ticket_id: string }[]>`
+    DELETE FROM ticket_votes
+    WHERE ticket_id = ${ticketId} AND user_id = ${userId}
+    RETURNING ticket_id
+  `;
+  return { deleted: rows.length > 0 };
+}

--- a/tracker/server/src/routes/discussion.ts
+++ b/tracker/server/src/routes/discussion.ts
@@ -1,0 +1,189 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import type {
+  CreateCommentRequest,
+  CreateCommentResponse,
+  ListCommentsResponse,
+  TicketVoteState,
+} from '@tracker/types';
+import { getPool } from '../db/pool.js';
+import {
+  insertComment,
+  listComments,
+  getVoteState,
+  addVote,
+  removeVote,
+} from '../db/discussion.js';
+import {
+  requireTrackerAuth,
+  requirePermission,
+  type AuthenticatedRequest,
+} from '../middleware/auth.js';
+
+// All discussion routes are nested under /tracker/api/tickets/:ticketId
+const router = Router({ mergeParams: true });
+
+/** POST /tracker/api/tickets/:ticketId/comments */
+router.post(
+  '/comments',
+  requireTrackerAuth,
+  requirePermission('ticket.comment'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ticketId = req.params['ticketId'] as string | undefined;
+    if (!ticketId) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Ticket not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    const { body, is_internal } = req.body as CreateCommentRequest;
+
+    if (typeof body !== 'string' || !body.trim()) {
+      res.status(422).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'body is required.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    const authed = req as AuthenticatedRequest;
+    const canViewInternal =
+      authed.trackerUser.role === 'moderator' || authed.trackerUser.role === 'committee';
+
+    // Non-privileged users cannot post internal comments
+    const isInternal = canViewInternal && (is_internal ?? false);
+
+    try {
+      const sql = getPool();
+      const result = await insertComment(
+        sql,
+        ticketId,
+        authed.trackerUser.id,
+        body.trim(),
+        isInternal,
+      );
+      const responseBody: CreateCommentResponse = { id: result.id };
+      res.status(201).json(responseBody);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** GET /tracker/api/tickets/:ticketId/comments */
+router.get(
+  '/comments',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ticketId = req.params['ticketId'] as string | undefined;
+    if (!ticketId) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Ticket not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    const authed = req as AuthenticatedRequest;
+    const includeInternal =
+      authed.trackerUser.role === 'moderator' || authed.trackerUser.role === 'committee';
+
+    try {
+      const sql = getPool();
+      const comments = await listComments(sql, ticketId, includeInternal);
+      const responseBody: ListCommentsResponse = { comments };
+      res.json(responseBody);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** GET /tracker/api/tickets/:ticketId/votes */
+router.get(
+  '/votes',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ticketId = req.params['ticketId'] as string | undefined;
+    if (!ticketId) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Ticket not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const sql = getPool();
+      const state = await getVoteState(sql, ticketId, (req as AuthenticatedRequest).trackerUser.id);
+      const responseBody: TicketVoteState = state;
+      res.json(responseBody);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** POST /tracker/api/tickets/:ticketId/votes — cast or retract a vote */
+router.post(
+  '/votes',
+  requireTrackerAuth,
+  requirePermission('ticket.vote'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ticketId = req.params['ticketId'] as string | undefined;
+    if (!ticketId) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Ticket not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    const { action } = req.body as { action?: string };
+    if (action !== 'add' && action !== 'remove') {
+      res.status(422).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'action must be "add" or "remove".',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const sql = getPool();
+      const userId = (req as AuthenticatedRequest).trackerUser.id;
+
+      if (action === 'add') {
+        await addVote(sql, ticketId, userId);
+      } else {
+        await removeVote(sql, ticketId, userId);
+      }
+
+      const state = await getVoteState(sql, ticketId, userId);
+      const responseBody: TicketVoteState = state;
+      res.json(responseBody);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export { router as discussionRouter };

--- a/tracker/types/src/discussion.ts
+++ b/tracker/types/src/discussion.ts
@@ -1,0 +1,33 @@
+/** A single comment on a ticket. */
+export interface TicketComment {
+  id: string;
+  ticket_id: string;
+  author_display_name: string;
+  body: string;
+  is_internal: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Request body for adding a comment. */
+export interface CreateCommentRequest {
+  body: string;
+  is_internal?: boolean;
+}
+
+/** Response body for a successfully created comment. */
+export interface CreateCommentResponse {
+  id: string;
+}
+
+/** Response body for listing comments on a ticket. */
+export interface ListCommentsResponse {
+  comments: TicketComment[];
+}
+
+/** Response body for the vote state on a ticket. */
+export interface TicketVoteState {
+  ticket_id: string;
+  vote_count: number;
+  user_has_voted: boolean;
+}

--- a/tracker/types/src/index.ts
+++ b/tracker/types/src/index.ts
@@ -1,5 +1,6 @@
 // @tracker/types — shared data contracts
 // Server and client both import from here; neither defines its own independently.
 export * from './common.js';
+export * from './discussion.js';
 export * from './tickets.js';
 export * from './users.js';


### PR DESCRIPTION
## Summary
- Adds `@tracker/types`: `TicketComment`, `CreateCommentRequest/Response`, `ListCommentsResponse`, `TicketVoteState`
- Adds `db/discussion.ts`: `insertComment`, `listComments`, `getVoteState`, `addVote`, `removeVote`
- Adds `routes/discussion.ts`: `POST /comments`, `GET /comments`, `GET /votes`, `POST /votes` (all nested under `/tracker/api/tickets/:ticketId`)
- Internal comment gating: only `moderator` and `committee` roles can post or view internal notes
- Vote cast/retract via `{ action: "add" | "remove" }` body; response always returns current vote state

## Test plan
- [ ] All CI jobs pass (typecheck, lint, build, unit-tests, integration-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)