### PR TITLE
feat(tracker): notification service and /me/notifications routes (TICKET-016)

### DIFF
--- a/tracker/server/src/app.ts
+++ b/tracker/server/src/app.ts
@@ -4,6 +4,7 @@ import type { HealthResponse, TrackerErrorResponse } from '@tracker/types';
 import { checkDbHealth } from './db/pool.js';
 import { ticketsRouter } from './routes/tickets.js';
 import { discussionRouter } from './routes/discussion.js';
+import { meRouter } from './routes/me.js';
 
 export function createApp() {
   const app = express();
@@ -19,6 +20,7 @@ export function createApp() {
   // API routes
   app.use('/tracker/api/tickets', ticketsRouter);
   app.use('/tracker/api/tickets/:ticketId', discussionRouter);
+  app.use('/tracker/api/me', meRouter);
 
   // Health checks — no auth required
   app.get('/tracker/health', (_req: Request, res: Response) => {

--- a/tracker/server/src/db/notifications.ts
+++ b/tracker/server/src/db/notifications.ts
@@ -1,0 +1,81 @@
+import type { Sql } from 'postgres';
+import type { UserNotification, NotificationEventType } from '@tracker/types';
+
+/**
+ * Inserts a notification_events row, then fans out user_notifications to all
+ * ticket subscribers excluding the actor.
+ *
+ * Called by the notification service — do not call directly from routes.
+ */
+export async function recordNotificationEvent(
+  sql: Sql,
+  ticketId: string,
+  actorId: string,
+  eventType: NotificationEventType,
+): Promise<void> {
+  await sql`
+    WITH event AS (
+      INSERT INTO notification_events (ticket_id, actor_id, event_type)
+      VALUES (${ticketId}, ${actorId}, ${eventType})
+      RETURNING id
+    )
+    INSERT INTO user_notifications (user_id, event_id)
+    SELECT ts.user_id, event.id
+    FROM ticket_subscriptions ts
+    CROSS JOIN event
+    WHERE ts.ticket_id = ${ticketId}
+      AND ts.user_id  <> ${actorId}
+    ON CONFLICT (user_id, event_id) DO NOTHING
+  `;
+}
+
+interface NotificationRow {
+  id: string;
+  ticket_id: string;
+  ticket_title: string;
+  event_type: NotificationEventType;
+  actor_display_name: string;
+  is_read: boolean;
+  created_at: string;
+}
+
+/** Returns all notifications for a user, newest first. */
+export async function listUserNotifications(
+  sql: Sql,
+  userId: string,
+): Promise<{ notifications: UserNotification[]; unread_count: number }> {
+  const rows = await sql<NotificationRow[]>`
+    SELECT
+      un.id,
+      ne.ticket_id,
+      t.title        AS ticket_title,
+      ne.event_type,
+      u.display_name AS actor_display_name,
+      un.is_read,
+      un.created_at::TEXT AS created_at
+    FROM user_notifications un
+    JOIN notification_events ne ON ne.id   = un.event_id
+    JOIN tickets              t  ON t.id   = ne.ticket_id
+    JOIN users                u  ON u.id   = ne.actor_id
+    WHERE un.user_id = ${userId}
+    ORDER BY un.created_at DESC
+  `;
+
+  const unread_count = rows.filter((r) => !r.is_read).length;
+  return { notifications: rows, unread_count };
+}
+
+/** Marks a notification as read. Returns true if the notification belonged to the user. */
+export async function markNotificationRead(
+  sql: Sql,
+  notificationId: string,
+  userId: string,
+): Promise<boolean> {
+  const rows = await sql<{ id: string }[]>`
+    UPDATE user_notifications
+    SET is_read = TRUE
+    WHERE id = ${notificationId} AND user_id = ${userId}
+    RETURNING id
+  `;
+  return rows.length > 0;
+}

--- a/tracker/server/src/routes/discussion.ts
+++ b/tracker/server/src/routes/discussion.ts
@@ -18,6 +18,7 @@ import {
   requirePermission,
   type AuthenticatedRequest,
 } from '../middleware/auth.js';
+import { fanoutNotification } from '../services/notifications.js';
 
 // All discussion routes are nested under /tracker/api/tickets/:ticketId
 const router = Router({ mergeParams: true });
@@ -69,6 +70,10 @@ router.post(
         body.trim(),
         isInternal,
       );
+      // Fanout only for public comments — internal notes don't notify community members
+      if (!isInternal) {
+        void fanoutNotification(sql, ticketId, authed.trackerUser.id, 'comment_added');
+      }
       const responseBody: CreateCommentResponse = { id: result.id };
       res.status(201).json(responseBody);
     } catch (err) {

--- a/tracker/server/src/routes/me.ts
+++ b/tracker/server/src/routes/me.ts
@@ -1,0 +1,64 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import type { ListNotificationsResponse } from '@tracker/types';
+import { getPool } from '../db/pool.js';
+import { listUserNotifications, markNotificationRead } from '../db/notifications.js';
+import { requireTrackerAuth, type AuthenticatedRequest } from '../middleware/auth.js';
+
+const router = Router();
+
+/** GET /tracker/api/me/notifications */
+router.get(
+  '/notifications',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const sql = getPool();
+      const userId = (req as AuthenticatedRequest).trackerUser.id;
+      const { notifications, unread_count } = await listUserNotifications(sql, userId);
+      const body: ListNotificationsResponse = { notifications, unread_count };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** PATCH /tracker/api/me/notifications/:id/read */
+router.patch(
+  '/notifications/:id/read',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const id = req.params['id'] as string | undefined;
+    if (!id) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Notification not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const sql = getPool();
+      const userId = (req as AuthenticatedRequest).trackerUser.id;
+      const found = await markNotificationRead(sql, id, userId);
+      if (!found) {
+        res.status(404).json({
+          error: {
+            code: 'NOT_FOUND',
+            message: 'Notification not found.',
+            correlationId: (req as AuthenticatedRequest).correlationId,
+          },
+        });
+        return;
+      }
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export { router as meRouter };

--- a/tracker/server/src/services/lifecycle.ts
+++ b/tracker/server/src/services/lifecycle.ts
@@ -1,6 +1,7 @@
 import type { Sql } from 'postgres';
 import type { CreateTicketInput } from '../db/tickets.js';
 import { getStatusId } from '../db/tickets.js';
+import { fanoutNotification } from './notifications.js';
 
 /**
  * Submits a new ticket.
@@ -48,6 +49,10 @@ export async function submitTicket(
 
   const ticket = rows[0];
   if (!ticket) throw new Error('submitTicket: no row returned');
+
+  // Fanout is fire-and-continue — notification failure does not fail the submission
+  void fanoutNotification(sql, ticket.id, submittedBy, 'status_changed');
+
   return { id: ticket.id };
 }
 
@@ -110,6 +115,8 @@ export async function transitionTicket(
     INSERT INTO ticket_status_history (ticket_id, from_status_id, to_status_id, changed_by, resolution_note)
     VALUES (${ticketId}, ${fromId}, ${toId}, ${changedBy}, ${resolutionNote ?? null})
   `;
+
+  void fanoutNotification(sql, ticketId, changedBy, 'status_changed');
 
   return { ok: true };
 }

--- a/tracker/server/src/services/notifications.ts
+++ b/tracker/server/src/services/notifications.ts
@@ -1,0 +1,22 @@
+import type { Sql } from 'postgres';
+import type { NotificationEventType } from '@tracker/types';
+import { recordNotificationEvent } from '../db/notifications.js';
+
+/**
+ * Fans out a notification event to all ticket subscribers (excluding the actor).
+ *
+ * This is fire-and-continue — errors are logged but not propagated, so a
+ * notification failure never blocks the primary operation.
+ */
+export async function fanoutNotification(
+  sql: Sql,
+  ticketId: string,
+  actorId: string,
+  eventType: NotificationEventType,
+): Promise<void> {
+  try {
+    await recordNotificationEvent(sql, ticketId, actorId, eventType);
+  } catch (err) {
+    console.error({ ticketId, actorId, eventType, err }, 'Notification fanout failed');
+  }
+}

--- a/tracker/types/src/index.ts
+++ b/tracker/types/src/index.ts
@@ -2,5 +2,6 @@
 // Server and client both import from here; neither defines its own independently.
 export * from './common.js';
 export * from './discussion.js';
+export * from './notifications.js';
 export * from './tickets.js';
 export * from './users.js';

--- a/tracker/types/src/notifications.ts
+++ b/tracker/types/src/notifications.ts
@@ -1,0 +1,19 @@
+/** The event types that trigger notification fanout. */
+export type NotificationEventType = 'status_changed' | 'comment_added';
+
+/** A single notification for a user. */
+export interface UserNotification {
+  id: string;
+  ticket_id: string;
+  ticket_title: string;
+  event_type: NotificationEventType;
+  actor_display_name: string;
+  is_read: boolean;
+  created_at: string;
+}
+
+/** Response body for GET /tracker/api/me/notifications */
+export interface ListNotificationsResponse {
+  notifications: UserNotification[];
+  unread_count: number;
+}


### PR DESCRIPTION
## Summary
- Adds `@tracker/types`: `UserNotification`, `NotificationEventType`, `ListNotificationsResponse`
- Adds `db/notifications.ts`: CTE-based fanout (event + per-subscriber `user_notifications`), list and mark-read queries
- Adds `services/notifications.ts`: fire-and-continue `fanoutNotification` wrapper (errors logged, never propagated)
- Wires fanout into `lifecycle.submitTicket` and `lifecycle.transitionTicket` (`status_changed` events)
- Wires fanout into discussion comment creation (`comment_added` events, public comments only)
- Adds `routes/me.ts`: `GET /tracker/api/me/notifications`, `PATCH /me/notifications/:id/read`

## Test plan
- [ ] All CI jobs pass (typecheck, lint, build, unit-tests, integration-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)