### PR TITLE
feat(tracker): user role assignment and revocation routes (TICKET-019)

### DIFF
--- a/tracker/server/src/app.ts
+++ b/tracker/server/src/app.ts
@@ -5,6 +5,7 @@ import { checkDbHealth } from './db/pool.js';
 import { ticketsRouter } from './routes/tickets.js';
 import { discussionRouter } from './routes/discussion.js';
 import { meRouter } from './routes/me.js';
+import { usersRouter } from './routes/users.js';
 
 export function createApp() {
   const app = express();
@@ -21,6 +22,7 @@ export function createApp() {
   app.use('/tracker/api/tickets', ticketsRouter);
   app.use('/tracker/api/tickets/:ticketId', discussionRouter);
   app.use('/tracker/api/me', meRouter);
+  app.use('/tracker/api/users', usersRouter);
 
   // Health checks — no auth required
   app.get('/tracker/health', (_req: Request, res: Response) => {

--- a/tracker/server/src/db/roles.ts
+++ b/tracker/server/src/db/roles.ts
@@ -1,0 +1,57 @@
+import type { Sql } from 'postgres';
+import type { RoleSlug } from '@tracker/types';
+
+/**
+ * Assigns a role to a user.
+ *
+ * Returns 'already_assigned' if the user already has this role active.
+ * Returns 'role_not_found' if the slug doesn't match a known role.
+ */
+export async function assignRole(
+  sql: Sql,
+  userId: string,
+  roleSlug: RoleSlug,
+  grantedBy: string,
+): Promise<{ ok: true } | { ok: false; reason: 'already_assigned' | 'role_not_found' }> {
+  const [role] = await sql<{ id: number }[]>`
+    SELECT id FROM roles WHERE name = ${roleSlug}
+  `;
+  if (!role) return { ok: false, reason: 'role_not_found' };
+
+  const rows = await sql<{ id: string }[]>`
+    INSERT INTO user_role_assignments (user_id, role_id, granted_by)
+    VALUES (${userId}, ${role.id}, ${grantedBy})
+    ON CONFLICT DO NOTHING
+    RETURNING id
+  `;
+  if (rows.length === 0) return { ok: false, reason: 'already_assigned' };
+  return { ok: true };
+}
+
+/**
+ * Revokes the active assignment of a role from a user.
+ *
+ * Returns false if no active assignment was found.
+ */
+export async function revokeRole(
+  sql: Sql,
+  userId: string,
+  roleSlug: RoleSlug,
+  revokedBy: string,
+): Promise<{ ok: true } | { ok: false; reason: 'not_assigned' | 'role_not_found' }> {
+  const [role] = await sql<{ id: number }[]>`
+    SELECT id FROM roles WHERE name = ${roleSlug}
+  `;
+  if (!role) return { ok: false, reason: 'role_not_found' };
+
+  const rows = await sql<{ id: string }[]>`
+    UPDATE user_role_assignments
+    SET revoked_at = now(), revoked_by = ${revokedBy}
+    WHERE user_id = ${userId}
+      AND role_id = ${role.id}
+      AND revoked_at IS NULL
+    RETURNING id
+  `;
+  if (rows.length === 0) return { ok: false, reason: 'not_assigned' };
+  return { ok: true };
+}

--- a/tracker/server/src/routes/users.ts
+++ b/tracker/server/src/routes/users.ts
@@ -1,0 +1,123 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import type { AssignRoleRequest, AssignRoleResponse, RoleSlug } from '@tracker/types';
+import { getPool } from '../db/pool.js';
+import { assignRole, revokeRole } from '../db/roles.js';
+import {
+  requireTrackerAuth,
+  requirePermission,
+  type AuthenticatedRequest,
+} from '../middleware/auth.js';
+
+const router = Router();
+
+const VALID_ROLES: ReadonlySet<string> = new Set(['moderator', 'committee']);
+
+/** POST /tracker/api/users/:userId/roles — assign a role to a user */
+router.post(
+  '/:userId/roles',
+  requireTrackerAuth,
+  requirePermission('user.role.assign'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const userId = req.params['userId'] as string | undefined;
+    if (!userId) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'User not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    const { role } = req.body as AssignRoleRequest;
+    if (typeof role !== 'string' || !VALID_ROLES.has(role)) {
+      res.status(422).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: `role must be one of: ${[...VALID_ROLES].join(', ')}.`,
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const sql = getPool();
+      const result = await assignRole(
+        sql,
+        userId,
+        role as RoleSlug,
+        (req as AuthenticatedRequest).trackerUser.id,
+      );
+
+      if (!result.ok) {
+        const code = result.reason === 'already_assigned' ? 'CONFLICT' : 'VALIDATION_ERROR';
+        const status = result.reason === 'already_assigned' ? 409 : 422;
+        res.status(status).json({
+          error: {
+            code,
+            message: result.reason,
+            correlationId: (req as AuthenticatedRequest).correlationId,
+          },
+        });
+        return;
+      }
+
+      const body: AssignRoleResponse = { user_id: userId, role: role as RoleSlug };
+      res.status(201).json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** DELETE /tracker/api/users/:userId/roles/:roleSlug — revoke a role from a user */
+router.delete(
+  '/:userId/roles/:roleSlug',
+  requireTrackerAuth,
+  requirePermission('user.role.assign'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const userId = req.params['userId'] as string | undefined;
+    const roleSlug = req.params['roleSlug'] as string | undefined;
+
+    if (!userId || !roleSlug || !VALID_ROLES.has(roleSlug)) {
+      res.status(422).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid user or role.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const sql = getPool();
+      const result = await revokeRole(
+        sql,
+        userId,
+        roleSlug as RoleSlug,
+        (req as AuthenticatedRequest).trackerUser.id,
+      );
+
+      if (!result.ok) {
+        const status = result.reason === 'not_assigned' ? 404 : 422;
+        res.status(status).json({
+          error: {
+            code: 'NOT_FOUND',
+            message: result.reason,
+            correlationId: (req as AuthenticatedRequest).correlationId,
+          },
+        });
+        return;
+      }
+
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export { router as usersRouter };

--- a/tracker/types/src/users.ts
+++ b/tracker/types/src/users.ts
@@ -15,3 +15,14 @@ export interface TrackerUser {
   account_status: AccountStatus;
   role: RoleSlug;
 }
+
+/** Request body for assigning a role to a user. */
+export interface AssignRoleRequest {
+  role: RoleSlug;
+}
+
+/** Response body for a role assignment or revocation. */
+export interface AssignRoleResponse {
+  user_id: string;
+  role: RoleSlug;
+}


### PR DESCRIPTION
## Summary
- Extends `@tracker/types` with `AssignRoleRequest` and `AssignRoleResponse`
- Adds `db/roles.ts`: `assignRole` (uses `ON CONFLICT DO NOTHING` against partial unique index) and `revokeRole` (sets `revoked_at`)
- Adds `routes/users.ts`: `POST /tracker/api/users/:userId/roles` and `DELETE /:userId/roles/:roleSlug`
- Both routes require `user.role.assign` permission (committee only)
- Only elevatable roles (`moderator`, `committee`) can be assigned — `community_member` is the implicit default

## Test plan
- [ ] All CI jobs pass (typecheck, lint, build, unit-tests, integration-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)