### PR TITLE
feat(tracker): lookups API route for ticket types, domains, and statuses (TICKET-020)

### DIFF
--- a/tracker/server/src/app.ts
+++ b/tracker/server/src/app.ts
@@ -6,6 +6,7 @@ import { ticketsRouter } from './routes/tickets.js';
 import { discussionRouter } from './routes/discussion.js';
 import { meRouter } from './routes/me.js';
 import { usersRouter } from './routes/users.js';
+import { lookupsRouter } from './routes/lookups.js';
 
 export function createApp() {
   const app = express();
@@ -23,6 +24,7 @@ export function createApp() {
   app.use('/tracker/api/tickets/:ticketId', discussionRouter);
   app.use('/tracker/api/me', meRouter);
   app.use('/tracker/api/users', usersRouter);
+  app.use('/tracker/api/lookups', lookupsRouter);
 
   // Health checks — no auth required
   app.get('/tracker/health', (_req: Request, res: Response) => {

--- a/tracker/server/src/routes/lookups.ts
+++ b/tracker/server/src/routes/lookups.ts
@@ -1,0 +1,43 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import type {
+  LookupsResponse,
+  TicketTypeLookup,
+  DomainLookup,
+  StatusLookup,
+  TicketTypeSlug,
+  DomainSlug,
+  StatusSlug,
+} from '@tracker/types';
+import { getPool } from '../db/pool.js';
+
+const router = Router();
+
+/** GET /tracker/api/lookups — returns ticket types, domains, and statuses */
+router.get('/', async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const sql = getPool();
+
+    const [ticketTypes, domains, statuses] = await Promise.all([
+      sql<{ id: number; slug: TicketTypeSlug; name: string }[]>`
+          SELECT id, slug, name FROM ticket_types ORDER BY sort_order
+        `,
+      sql<{ id: number; slug: DomainSlug; name: string }[]>`
+          SELECT id, slug, name FROM domains ORDER BY sort_order
+        `,
+      sql<{ id: number; slug: StatusSlug; name: string; is_terminal: boolean }[]>`
+          SELECT id, slug, name, is_terminal FROM statuses ORDER BY id
+        `,
+    ]);
+
+    const body: LookupsResponse = {
+      ticket_types: ticketTypes as TicketTypeLookup[],
+      domains: domains as DomainLookup[],
+      statuses: statuses as StatusLookup[],
+    };
+    res.json(body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export { router as lookupsRouter };

--- a/tracker/types/src/index.ts
+++ b/tracker/types/src/index.ts
@@ -2,6 +2,7 @@
 // Server and client both import from here; neither defines its own independently.
 export * from './common.js';
 export * from './discussion.js';
+export * from './lookups.js';
 export * from './notifications.js';
 export * from './tickets.js';
 export * from './users.js';

--- a/tracker/types/src/lookups.ts
+++ b/tracker/types/src/lookups.ts
@@ -1,0 +1,30 @@
+import type { TicketTypeSlug, DomainSlug, StatusSlug } from './tickets.js';
+
+/** A ticket type lookup row. */
+export interface TicketTypeLookup {
+  id: number;
+  slug: TicketTypeSlug;
+  name: string;
+}
+
+/** A domain lookup row. */
+export interface DomainLookup {
+  id: number;
+  slug: DomainSlug;
+  name: string;
+}
+
+/** A status lookup row. */
+export interface StatusLookup {
+  id: number;
+  slug: StatusSlug;
+  name: string;
+  is_terminal: boolean;
+}
+
+/** Response body for GET /tracker/api/lookups */
+export interface LookupsResponse {
+  ticket_types: TicketTypeLookup[];
+  domains: DomainLookup[];
+  statuses: StatusLookup[];
+}


### PR DESCRIPTION
## Summary
- Adds `@tracker/types`: `TicketTypeLookup`, `DomainLookup`, `StatusLookup`, `LookupsResponse`
- Adds `routes/lookups.ts`: `GET /tracker/api/lookups` — returns all ticket types (sorted), domains (sorted), and statuses ordered by id
- No auth required — the client needs lookups to render the submission form
- Uses `Promise.all` for parallel queries

## Test plan
- [ ] All CI jobs pass (typecheck, lint, build, unit-tests, integration-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)