### PR TITLE
feat(tracker): implement React frontend client (TICKET-021)

### DIFF
--- a/tracker/client/src/App.tsx
+++ b/tracker/client/src/App.tsx
@@ -1,3 +1,24 @@
+import '@mantine/core/styles.css';
+import { MantineProvider } from '@mantine/core';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { NavHeader } from './components/NavHeader.js';
+import { TicketListPage } from './pages/TicketListPage.js';
+import { TicketDetailPage } from './pages/TicketDetailPage.js';
+import { SubmitTicketPage } from './pages/SubmitTicketPage.js';
+import { NotificationsPage } from './pages/NotificationsPage.js';
+
 export default function App() {
-  return <div>Tracker</div>;
+  return (
+    <MantineProvider>
+      <BrowserRouter basename="/tracker">
+        <NavHeader />
+        <Routes>
+          <Route path="/" element={<TicketListPage />} />
+          <Route path="/tickets/:id" element={<TicketDetailPage />} />
+          <Route path="/submit" element={<SubmitTicketPage />} />
+          <Route path="/notifications" element={<NotificationsPage />} />
+        </Routes>
+      </BrowserRouter>
+    </MantineProvider>
+  );
 }

--- a/tracker/client/src/api.ts
+++ b/tracker/client/src/api.ts
@@ -1,0 +1,77 @@
+import type {
+  ListTicketsResponse,
+  GetTicketResponse,
+  CreateTicketRequest,
+  CreateTicketResponse,
+  ListCommentsResponse,
+  CreateCommentRequest,
+  CreateCommentResponse,
+  TicketVoteState,
+  ListNotificationsResponse,
+  LookupsResponse,
+  TransitionTicketRequest,
+  TransitionTicketResponse,
+} from '@tracker/types';
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    headers: { 'Content-Type': 'application/json', ...init?.headers },
+  });
+  if (!res.ok) throw new ApiError(res.status, `${res.status} ${res.statusText}`);
+  return res.json() as Promise<T>;
+}
+
+export const api = {
+  getLookups: () => apiFetch<LookupsResponse>('/tracker/api/lookups'),
+
+  listTickets: (limit = 25, offset = 0) =>
+    apiFetch<ListTicketsResponse>(`/tracker/api/tickets?limit=${limit}&offset=${offset}`),
+
+  getTicket: (id: string) => apiFetch<GetTicketResponse>(`/tracker/api/tickets/${id}`),
+
+  createTicket: (body: CreateTicketRequest) =>
+    apiFetch<CreateTicketResponse>('/tracker/api/tickets', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  listComments: (ticketId: string) =>
+    apiFetch<ListCommentsResponse>(`/tracker/api/tickets/${ticketId}/comments`),
+
+  addComment: (ticketId: string, body: CreateCommentRequest) =>
+    apiFetch<CreateCommentResponse>(`/tracker/api/tickets/${ticketId}/comments`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+
+  getVotes: (ticketId: string) =>
+    apiFetch<TicketVoteState>(`/tracker/api/tickets/${ticketId}/votes`),
+
+  castVote: (ticketId: string, action: 'add' | 'remove') =>
+    apiFetch<TicketVoteState>(`/tracker/api/tickets/${ticketId}/votes`, {
+      method: 'POST',
+      body: JSON.stringify({ action }),
+    }),
+
+  getNotifications: () => apiFetch<ListNotificationsResponse>('/tracker/api/me/notifications'),
+
+  markNotificationRead: (id: string) =>
+    fetch(`/tracker/api/me/notifications/${id}/read`, { method: 'PATCH' }),
+
+  transitionTicket: (id: string, body: TransitionTicketRequest) =>
+    apiFetch<TransitionTicketResponse>(`/tracker/api/tickets/${id}/status`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    }),
+};

--- a/tracker/client/src/components/NavHeader.tsx
+++ b/tracker/client/src/components/NavHeader.tsx
@@ -1,0 +1,30 @@
+import { Box, Group, Text, Anchor } from '@mantine/core';
+import { Link } from 'react-router-dom';
+
+export function NavHeader() {
+  return (
+    <Box
+      component="header"
+      px="md"
+      py="sm"
+      style={{ borderBottom: '1px solid var(--mantine-color-gray-3)' }}
+    >
+      <Group justify="space-between">
+        <Text fw={700} size="lg" component={Link} to="/" style={{ textDecoration: 'none' }}>
+          Hanabi Tracker
+        </Text>
+        <Group gap="md">
+          <Anchor component={Link} to="/">
+            All Tickets
+          </Anchor>
+          <Anchor component={Link} to="/submit">
+            Submit
+          </Anchor>
+          <Anchor component={Link} to="/notifications">
+            Notifications
+          </Anchor>
+        </Group>
+      </Group>
+    </Box>
+  );
+}

--- a/tracker/client/src/components/TicketStatusBadge.tsx
+++ b/tracker/client/src/components/TicketStatusBadge.tsx
@@ -1,0 +1,26 @@
+import { Badge } from '@mantine/core';
+import type { StatusSlug } from '@tracker/types';
+
+const STATUS_COLORS: Record<StatusSlug, string> = {
+  submitted: 'blue',
+  triaged: 'indigo',
+  in_review: 'violet',
+  decided: 'yellow',
+  resolved: 'green',
+  rejected: 'red',
+  closed: 'gray',
+};
+
+interface TicketStatusBadgeProps {
+  status: StatusSlug;
+}
+
+export function TicketStatusBadge({ status }: TicketStatusBadgeProps) {
+  const color = STATUS_COLORS[status];
+  const label = status.replace(/_/g, ' ');
+  return (
+    <Badge color={color} variant="light">
+      {label}
+    </Badge>
+  );
+}

--- a/tracker/client/src/pages/NotificationsPage.tsx
+++ b/tracker/client/src/pages/NotificationsPage.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Container,
+  Title,
+  Stack,
+  Text,
+  Loader,
+  Alert,
+  Card,
+  Group,
+  Badge,
+  Anchor,
+  Button,
+} from '@mantine/core';
+import type { UserNotification } from '@tracker/types';
+import { api, ApiError } from '../api.js';
+
+export function NotificationsPage() {
+  const [notifications, setNotifications] = useState<UserNotification[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .getNotifications()
+      .then((data) => setNotifications(data.notifications))
+      .catch((err: unknown) => {
+        setError(err instanceof ApiError ? err.message : 'Failed to load notifications.');
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  function handleMarkRead(id: string) {
+    api.markNotificationRead(id).then(() => {
+      setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, is_read: true } : n)));
+    });
+  }
+
+  return (
+    <Container size="md" py="md">
+      <Stack gap="md">
+        <Title order={2}>Notifications</Title>
+
+        {loading && <Loader />}
+        {error && <Alert color="red">{error}</Alert>}
+
+        {!loading && !error && notifications.length === 0 && (
+          <Text c="dimmed">No notifications.</Text>
+        )}
+
+        {notifications.map((n) => (
+          <Card key={n.id} withBorder padding="sm" opacity={n.is_read ? 0.6 : 1}>
+            <Group justify="space-between" align="flex-start">
+              <Stack gap={2}>
+                <Text size="sm" fw={n.is_read ? 400 : 600}>
+                  <Anchor component={Link} to={`/tickets/${n.ticket_id}`}>
+                    {n.ticket_title}
+                  </Anchor>
+                </Text>
+                <Text size="xs" c="dimmed">
+                  {n.event_type === 'status_changed' ? 'Status changed' : 'New comment'} by{' '}
+                  {n.actor_display_name} · {new Date(n.created_at).toLocaleString()}
+                </Text>
+              </Stack>
+              <Group gap="xs">
+                {!n.is_read && (
+                  <Badge size="xs" color="blue">
+                    new
+                  </Badge>
+                )}
+                {!n.is_read && (
+                  <Button size="xs" variant="subtle" onClick={() => handleMarkRead(n.id)}>
+                    Mark read
+                  </Button>
+                )}
+              </Group>
+            </Group>
+          </Card>
+        ))}
+      </Stack>
+    </Container>
+  );
+}

--- a/tracker/client/src/pages/SubmitTicketPage.tsx
+++ b/tracker/client/src/pages/SubmitTicketPage.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Container,
+  Title,
+  Stack,
+  TextInput,
+  Textarea,
+  Select,
+  Button,
+  Alert,
+  Loader,
+} from '@mantine/core';
+import type { LookupsResponse, BugSeverity, BugReproducibility } from '@tracker/types';
+import { api, ApiError } from '../api.js';
+
+const SEVERITY_OPTIONS: { value: BugSeverity; label: string }[] = [
+  { value: 'cosmetic', label: 'Cosmetic' },
+  { value: 'functional', label: 'Functional' },
+  { value: 'blocking', label: 'Blocking' },
+];
+
+const REPRODUCIBILITY_OPTIONS: { value: BugReproducibility; label: string }[] = [
+  { value: 'always', label: 'Always' },
+  { value: 'sometimes', label: 'Sometimes' },
+  { value: 'once', label: 'Once' },
+];
+
+export function SubmitTicketPage() {
+  const navigate = useNavigate();
+  const [lookups, setLookups] = useState<LookupsResponse | null>(null);
+  const [lookupsError, setLookupsError] = useState<string | null>(null);
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [typeId, setTypeId] = useState<string | null>(null);
+  const [domainId, setDomainId] = useState<string | null>(null);
+  const [severity, setSeverity] = useState<string | null>(null);
+  const [reproducibility, setReproducibility] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .getLookups()
+      .then(setLookups)
+      .catch((err: unknown) => {
+        setLookupsError(err instanceof ApiError ? err.message : 'Failed to load options.');
+      });
+  }, []);
+
+  const selectedTypeName = lookups?.ticket_types.find((t) => String(t.id) === typeId)?.slug;
+  const isBugType = selectedTypeName === 'bug';
+
+  function handleSubmit() {
+    if (!title.trim() || !description.trim() || !typeId || !domainId) return;
+    setSubmitting(true);
+    setSubmitError(null);
+
+    const body = {
+      title: title.trim(),
+      description: description.trim(),
+      type_id: Number(typeId),
+      domain_id: Number(domainId),
+      ...(isBugType && severity ? { severity: severity as BugSeverity } : {}),
+      ...(isBugType && reproducibility
+        ? { reproducibility: reproducibility as BugReproducibility }
+        : {}),
+    };
+
+    api
+      .createTicket(body)
+      .then((res) => navigate(`/tickets/${res.id}`))
+      .catch((err: unknown) => {
+        setSubmitError(err instanceof ApiError ? err.message : 'Failed to submit ticket.');
+      })
+      .finally(() => setSubmitting(false));
+  }
+
+  if (!lookups && !lookupsError) return <Loader m="md" />;
+  if (lookupsError)
+    return (
+      <Alert color="red" m="md">
+        {lookupsError}
+      </Alert>
+    );
+  if (!lookups) return null;
+
+  const typeData = lookups.ticket_types.map((t) => ({
+    value: String(t.id),
+    label: t.name,
+  }));
+
+  const domainData = lookups.domains.map((d) => ({
+    value: String(d.id),
+    label: d.name,
+  }));
+
+  const isValid = title.trim() && description.trim() && typeId && domainId;
+
+  return (
+    <Container size="sm" py="md">
+      <Stack gap="md">
+        <Title order={2}>Submit a Ticket</Title>
+
+        {submitError && <Alert color="red">{submitError}</Alert>}
+
+        <TextInput
+          label="Title"
+          placeholder="Brief summary of the issue"
+          required
+          value={title}
+          onChange={(e) => setTitle(e.currentTarget.value)}
+        />
+
+        <Textarea
+          label="Description"
+          placeholder="Describe the issue in detail"
+          required
+          minRows={5}
+          value={description}
+          onChange={(e) => setDescription(e.currentTarget.value)}
+        />
+
+        <Select
+          label="Type"
+          placeholder="Select type"
+          required
+          data={typeData}
+          value={typeId}
+          onChange={setTypeId}
+        />
+
+        <Select
+          label="Domain"
+          placeholder="Select domain"
+          required
+          data={domainData}
+          value={domainId}
+          onChange={setDomainId}
+        />
+
+        {isBugType && (
+          <>
+            <Select
+              label="Severity"
+              placeholder="Select severity"
+              data={SEVERITY_OPTIONS}
+              value={severity}
+              onChange={setSeverity}
+            />
+            <Select
+              label="Reproducibility"
+              placeholder="Select reproducibility"
+              data={REPRODUCIBILITY_OPTIONS}
+              value={reproducibility}
+              onChange={setReproducibility}
+            />
+          </>
+        )}
+
+        <Button onClick={handleSubmit} loading={submitting} disabled={!isValid}>
+          Submit Ticket
+        </Button>
+      </Stack>
+    </Container>
+  );
+}

--- a/tracker/client/src/pages/TicketDetailPage.tsx
+++ b/tracker/client/src/pages/TicketDetailPage.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  Container,
+  Title,
+  Stack,
+  Group,
+  Text,
+  Badge,
+  Loader,
+  Alert,
+  Divider,
+  Textarea,
+  Button,
+  Card,
+  Box,
+} from '@mantine/core';
+import type { TicketDetail, TicketComment, TicketVoteState } from '@tracker/types';
+import { api, ApiError } from '../api.js';
+import { TicketStatusBadge } from '../components/TicketStatusBadge.js';
+
+export function TicketDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [ticket, setTicket] = useState<TicketDetail | null>(null);
+  const [comments, setComments] = useState<TicketComment[]>([]);
+  const [votes, setVotes] = useState<TicketVoteState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [commentBody, setCommentBody] = useState('');
+  const [submittingComment, setSubmittingComment] = useState(false);
+  const [votingInFlight, setVotingInFlight] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    Promise.all([api.getTicket(id), api.listComments(id), api.getVotes(id)])
+      .then(([t, c, v]) => {
+        setTicket(t);
+        setComments(c.comments);
+        setVotes(v);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof ApiError ? err.message : 'Failed to load ticket.');
+      })
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  function handleAddComment() {
+    if (!id || !commentBody.trim()) return;
+    setSubmittingComment(true);
+    api
+      .addComment(id, { body: commentBody.trim() })
+      .then(() => api.listComments(id))
+      .then((c) => {
+        setComments(c.comments);
+        setCommentBody('');
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof ApiError ? err.message : 'Failed to post comment.');
+      })
+      .finally(() => setSubmittingComment(false));
+  }
+
+  function handleVote() {
+    if (!id || !votes || votingInFlight) return;
+    setVotingInFlight(true);
+    const action = votes.user_has_voted ? 'remove' : 'add';
+    api
+      .castVote(id, action)
+      .then((v) => setVotes(v))
+      .catch((err: unknown) => {
+        setError(err instanceof ApiError ? err.message : 'Failed to cast vote.');
+      })
+      .finally(() => setVotingInFlight(false));
+  }
+
+  if (loading) return <Loader m="md" />;
+  if (error)
+    return (
+      <Alert color="red" m="md">
+        {error}
+      </Alert>
+    );
+  if (!ticket) return null;
+
+  return (
+    <Container size="md" py="md">
+      <Stack gap="lg">
+        <Stack gap="xs">
+          <Group justify="space-between" align="flex-start">
+            <Title order={2}>{ticket.title}</Title>
+            <TicketStatusBadge status={ticket.status_slug} />
+          </Group>
+          <Group gap="xs">
+            <Badge variant="outline">{ticket.type_slug.replace(/_/g, ' ')}</Badge>
+            <Badge variant="outline" color="teal">
+              {ticket.domain_slug.replace(/_/g, ' ')}
+            </Badge>
+            {ticket.severity && (
+              <Badge variant="outline" color="orange">
+                {ticket.severity}
+              </Badge>
+            )}
+            {ticket.reproducibility && (
+              <Badge variant="outline" color="grape">
+                {ticket.reproducibility}
+              </Badge>
+            )}
+          </Group>
+          <Group gap="xs">
+            <Text size="sm" c="dimmed">
+              Submitted by {ticket.submitted_by_display_name}
+            </Text>
+            <Text size="sm" c="dimmed">
+              · {new Date(ticket.created_at).toLocaleDateString()}
+            </Text>
+          </Group>
+        </Stack>
+
+        <Text>{ticket.description}</Text>
+
+        {votes && (
+          <Group>
+            <Button
+              variant={votes.user_has_voted ? 'filled' : 'outline'}
+              size="sm"
+              onClick={handleVote}
+              loading={votingInFlight}
+            >
+              {votes.user_has_voted ? '▲ Voted' : '▲ Vote'} ({votes.vote_count})
+            </Button>
+          </Group>
+        )}
+
+        <Divider label="Comments" labelPosition="left" />
+
+        <Stack gap="sm">
+          {comments.length === 0 && (
+            <Text c="dimmed" size="sm">
+              No comments yet.
+            </Text>
+          )}
+          {comments.map((comment) => (
+            <Card key={comment.id} withBorder padding="sm">
+              <Group justify="space-between" mb="xs">
+                <Text fw={600} size="sm">
+                  {comment.author_display_name}
+                </Text>
+                <Group gap="xs">
+                  {comment.is_internal && (
+                    <Badge size="xs" color="gray">
+                      internal
+                    </Badge>
+                  )}
+                  <Text size="xs" c="dimmed">
+                    {new Date(comment.created_at).toLocaleString()}
+                  </Text>
+                </Group>
+              </Group>
+              <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+                {comment.body}
+              </Text>
+            </Card>
+          ))}
+        </Stack>
+
+        <Box>
+          <Textarea
+            label="Add a comment"
+            placeholder="Write your comment..."
+            value={commentBody}
+            onChange={(e) => setCommentBody(e.currentTarget.value)}
+            minRows={3}
+            mb="xs"
+          />
+          <Button
+            onClick={handleAddComment}
+            loading={submittingComment}
+            disabled={!commentBody.trim()}
+          >
+            Post comment
+          </Button>
+        </Box>
+      </Stack>
+    </Container>
+  );
+}

--- a/tracker/client/src/pages/TicketListPage.tsx
+++ b/tracker/client/src/pages/TicketListPage.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react';
+import {
+  Container,
+  Title,
+  Stack,
+  Table,
+  Loader,
+  Alert,
+  Text,
+  Anchor,
+  Pagination,
+  Group,
+} from '@mantine/core';
+import { Link } from 'react-router-dom';
+import type { TicketSummary } from '@tracker/types';
+import { api, ApiError } from '../api.js';
+import { TicketStatusBadge } from '../components/TicketStatusBadge.js';
+
+const PAGE_SIZE = 25;
+
+export function TicketListPage() {
+  const [tickets, setTickets] = useState<TicketSummary[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    const offset = (page - 1) * PAGE_SIZE;
+    api
+      .listTickets(PAGE_SIZE, offset)
+      .then((data) => {
+        setTickets(data.tickets);
+        setTotal(data.total);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof ApiError ? err.message : 'Failed to load tickets.');
+      })
+      .finally(() => setLoading(false));
+  }, [page]);
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <Container size="lg" py="md">
+      <Stack gap="md">
+        <Title order={2}>Tickets</Title>
+
+        {loading && <Loader />}
+        {error && <Alert color="red">{error}</Alert>}
+
+        {!loading && !error && (
+          <>
+            <Table highlightOnHover>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Title</Table.Th>
+                  <Table.Th>Type</Table.Th>
+                  <Table.Th>Domain</Table.Th>
+                  <Table.Th>Status</Table.Th>
+                  <Table.Th>Submitted by</Table.Th>
+                  <Table.Th>Created</Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {tickets.length === 0 && (
+                  <Table.Tr>
+                    <Table.Td colSpan={6}>
+                      <Text c="dimmed" ta="center">
+                        No tickets found.
+                      </Text>
+                    </Table.Td>
+                  </Table.Tr>
+                )}
+                {tickets.map((ticket) => (
+                  <Table.Tr key={ticket.id}>
+                    <Table.Td>
+                      <Anchor component={Link} to={`/tickets/${ticket.id}`}>
+                        {ticket.title}
+                      </Anchor>
+                    </Table.Td>
+                    <Table.Td>{ticket.type_slug.replace(/_/g, ' ')}</Table.Td>
+                    <Table.Td>{ticket.domain_slug.replace(/_/g, ' ')}</Table.Td>
+                    <Table.Td>
+                      <TicketStatusBadge status={ticket.status_slug} />
+                    </Table.Td>
+                    <Table.Td>{ticket.submitted_by_display_name}</Table.Td>
+                    <Table.Td>{new Date(ticket.created_at).toLocaleDateString()}</Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+
+            <Group justify="center">
+              <Pagination value={page} onChange={setPage} total={totalPages} />
+            </Group>
+          </>
+        )}
+      </Stack>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- Typed API client (`api.ts`) wrapping all tracker REST endpoints
- `App.tsx` wired with MantineProvider and react-router-dom v7 BrowserRouter (basename `/tracker`)
- Pages: ticket list (paginated), ticket detail (comments + voting), submit ticket (form backed by lookups), notifications (mark-read)
- Reusable components: `NavHeader`, `TicketStatusBadge`

## Test plan
- [ ] Typecheck passes: `pnpm --filter @tracker/client run typecheck`
- [ ] Lint passes: `pnpm --filter @tracker/client run lint`
- [ ] Unit tests pass: `pnpm --filter @tracker/client run test:unit`
- [ ] Build passes: `pnpm run build`
- [ ] Manual smoke: dev server proxies `/tracker/api/*` to Express at port 4001

🤖 Generated with [Claude Code](https://claude.com/claude-code)