### PR TITLE
feat(tracker): moderation and committee API endpoints (TICKET-022)

### DIFF
--- a/tracker/server/migrations/20260327250000_ticket_moderation_fields.sql
+++ b/tracker/server/migrations/20260327250000_ticket_moderation_fields.sql
@@ -1,0 +1,14 @@
+-- Up Migration
+
+-- Flag for committee review (set by moderator/committee)
+ALTER TABLE tickets ADD COLUMN ready_for_review_at TIMESTAMPTZ;
+ALTER TABLE tickets ADD COLUMN flagged_by UUID REFERENCES users (id);
+
+-- Duplicate ticket reference (set when a ticket is closed as a duplicate)
+ALTER TABLE tickets ADD COLUMN duplicate_of UUID REFERENCES tickets (id);
+
+-- Down Migration
+
+ALTER TABLE tickets DROP COLUMN duplicate_of;
+ALTER TABLE tickets DROP COLUMN flagged_by;
+ALTER TABLE tickets DROP COLUMN ready_for_review_at;

--- a/tracker/server/src/db/moderation.ts
+++ b/tracker/server/src/db/moderation.ts
@@ -1,0 +1,119 @@
+import type { Sql } from 'postgres';
+import type { TicketSummary } from '@tracker/types';
+
+/** Flag a ticket ready for committee review. Overwrites any existing flag. */
+export async function flagTicketForReview(
+  sql: Sql,
+  ticketId: string,
+  flaggedById: string,
+): Promise<void> {
+  await sql`
+    UPDATE tickets
+    SET ready_for_review_at = now(),
+        flagged_by           = ${flaggedById}
+    WHERE id = ${ticketId}
+  `;
+}
+
+/** Clear the ready-for-review flag on a ticket. No-op if not set. */
+export async function clearReviewFlag(sql: Sql, ticketId: string): Promise<void> {
+  await sql`
+    UPDATE tickets
+    SET ready_for_review_at = NULL,
+        flagged_by           = NULL
+    WHERE id = ${ticketId}
+  `;
+}
+
+/** Mark a ticket as a duplicate and close it. */
+export async function closeAsDuplicate(
+  sql: Sql,
+  ticketId: string,
+  canonicalTicketId: string,
+  closedStatusId: number,
+  changedById: string,
+): Promise<void> {
+  await sql`
+    WITH updated AS (
+      UPDATE tickets
+      SET current_status_id = ${closedStatusId},
+          duplicate_of      = ${canonicalTicketId},
+          updated_at        = now()
+      WHERE id   = ${ticketId}
+        AND id  <> ${canonicalTicketId}
+      RETURNING id
+    )
+    INSERT INTO ticket_status_history (ticket_id, from_status_id, to_status_id, changed_by, resolution_note)
+    SELECT
+      t.id,
+      t.current_status_id,
+      ${closedStatusId},
+      ${changedById},
+      'Closed as duplicate of ' || ${canonicalTicketId}
+    FROM tickets t
+    JOIN updated ON t.id = updated.id
+  `;
+}
+
+/** Return the canonical ticket id that this ticket is a duplicate of, or null. */
+export async function getDuplicateOf(sql: Sql, ticketId: string): Promise<string | null> {
+  const rows = await sql<{ duplicate_of: string | null }[]>`
+    SELECT duplicate_of FROM tickets WHERE id = ${ticketId}
+  `;
+  return rows[0]?.duplicate_of ?? null;
+}
+
+/** Return all tickets flagged ready_for_review_at IS NOT NULL, ordered oldest flag first. */
+export async function listReadyForReviewTickets(sql: Sql): Promise<TicketSummary[]> {
+  return sql<TicketSummary[]>`
+    SELECT
+      t.id,
+      t.title,
+      tt.slug AS type_slug,
+      d.slug  AS domain_slug,
+      s.slug  AS status_slug,
+      s.is_terminal,
+      u.display_name AS submitted_by_display_name,
+      t.created_at,
+      t.updated_at
+    FROM tickets t
+    JOIN ticket_types tt ON tt.id = t.type_id
+    JOIN domains      d  ON d.id  = t.domain_id
+    JOIN statuses     s  ON s.id  = t.current_status_id
+    JOIN users        u  ON u.id  = t.submitted_by
+    WHERE t.ready_for_review_at IS NOT NULL
+    ORDER BY t.ready_for_review_at ASC
+  `;
+}
+
+/** Return open (non-terminal) tickets ordered by vote count descending. */
+export async function getPlanningSignal(
+  sql: Sql,
+  typeId?: number,
+  domainId?: number,
+): Promise<(TicketSummary & { vote_count: number })[]> {
+  return sql<(TicketSummary & { vote_count: number })[]>`
+    SELECT
+      t.id,
+      t.title,
+      tt.slug AS type_slug,
+      d.slug  AS domain_slug,
+      s.slug  AS status_slug,
+      s.is_terminal,
+      u.display_name AS submitted_by_display_name,
+      t.created_at,
+      t.updated_at,
+      COUNT(tv.user_id)::int AS vote_count
+    FROM tickets t
+    JOIN ticket_types tt ON tt.id = t.type_id
+    JOIN domains      d  ON d.id  = t.domain_id
+    JOIN statuses     s  ON s.id  = t.current_status_id
+    JOIN users        u  ON u.id  = t.submitted_by
+    LEFT JOIN ticket_votes tv ON tv.ticket_id = t.id
+    WHERE s.is_terminal = FALSE
+      ${typeId !== undefined ? sql`AND t.type_id = ${typeId}` : sql``}
+      ${domainId !== undefined ? sql`AND t.domain_id = ${domainId}` : sql``}
+    GROUP BY t.id, tt.slug, d.slug, s.slug, s.is_terminal, u.display_name
+    ORDER BY vote_count DESC, t.created_at ASC
+  `;
+}

--- a/tracker/server/src/middleware/auth.ts
+++ b/tracker/server/src/middleware/auth.ts
@@ -35,6 +35,7 @@ const ROLE_PERMISSIONS: Record<string, ReadonlySet<string>> = {
     'ticket.triage',
     'ticket.transition',
     'ticket.view_internal',
+    'ticket.flag_for_review',
   ]),
   committee: new Set([
     'ticket.create',
@@ -44,6 +45,7 @@ const ROLE_PERMISSIONS: Record<string, ReadonlySet<string>> = {
     'ticket.transition',
     'ticket.view_internal',
     'ticket.decide',
+    'ticket.flag_for_review',
     'user.role.assign',
   ]),
 };

--- a/tracker/server/src/routes/tickets.ts
+++ b/tracker/server/src/routes/tickets.ts
@@ -8,8 +8,16 @@ import type {
   TransitionTicketResponse,
 } from '@tracker/types';
 import { getPool } from '../db/pool.js';
-import { listTickets, getTicketById } from '../db/tickets.js';
+import { listTickets, getTicketById, getStatusId } from '../db/tickets.js';
 import { submitTicket, transitionTicket } from '../services/lifecycle.js';
+import {
+  flagTicketForReview,
+  clearReviewFlag,
+  closeAsDuplicate,
+  getDuplicateOf,
+  listReadyForReviewTickets,
+  getPlanningSignal,
+} from '../db/moderation.js';
 import {
   requireTrackerAuth,
   requirePermission,
@@ -78,6 +86,44 @@ router.get(
       const { tickets, total } = await listTickets(sql, { limit, offset });
       const body: ListTicketsResponse = { tickets, total, limit, offset };
       res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** GET /tracker/api/tickets/ready-for-review — tickets flagged for committee review */
+router.get(
+  '/ready-for-review',
+  requireTrackerAuth,
+  requirePermission('ticket.decide'),
+  async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const sql = getPool();
+      const tickets = await listReadyForReviewTickets(sql);
+      res.json({ tickets });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** GET /tracker/api/tickets/planning-signal — open tickets ranked by vote count */
+router.get(
+  '/planning-signal',
+  requireTrackerAuth,
+  requirePermission('ticket.decide'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const rawTypeId = req.query['type_id'];
+    const rawDomainId = req.query['domain_id'];
+    const typeId = typeof rawTypeId === 'string' && rawTypeId ? Number(rawTypeId) : undefined;
+    const domainId =
+      typeof rawDomainId === 'string' && rawDomainId ? Number(rawDomainId) : undefined;
+
+    try {
+      const sql = getPool();
+      const tickets = await getPlanningSignal(sql, typeId, domainId);
+      res.json({ tickets });
     } catch (err) {
       next(err);
     }
@@ -199,6 +245,144 @@ router.patch(
         status_slug: ticket.status_slug,
       };
       res.json(responseBody);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** POST /tracker/api/tickets/:id/flag — mark ticket ready for committee review */
+router.post(
+  '/:id/flag',
+  requireTrackerAuth,
+  requirePermission('ticket.flag_for_review'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const id = req.params['id'] as string | undefined;
+    if (!id) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Ticket not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+    try {
+      const sql = getPool();
+      await flagTicketForReview(sql, id, (req as AuthenticatedRequest).trackerUser.id);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** DELETE /tracker/api/tickets/:id/flag — clear the ready-for-review flag */
+router.delete(
+  '/:id/flag',
+  requireTrackerAuth,
+  requirePermission('ticket.flag_for_review'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const id = req.params['id'] as string | undefined;
+    if (!id) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Ticket not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+    try {
+      const sql = getPool();
+      await clearReviewFlag(sql, id);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** POST /tracker/api/tickets/:id/duplicate — close a ticket as duplicate of another */
+router.post(
+  '/:id/duplicate',
+  requireTrackerAuth,
+  requirePermission('ticket.triage'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const id = req.params['id'] as string | undefined;
+    if (!id) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Ticket not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    const { canonical_ticket_id } = req.body as { canonical_ticket_id?: string };
+    if (!canonical_ticket_id || typeof canonical_ticket_id !== 'string') {
+      res.status(422).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'canonical_ticket_id is required.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    if (canonical_ticket_id === id) {
+      res.status(422).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'A ticket cannot be a duplicate of itself.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const sql = getPool();
+
+      // Ensure canonical ticket exists and is not itself a duplicate
+      const canonical = await getTicketById(sql, canonical_ticket_id);
+      if (!canonical) {
+        res.status(404).json({
+          error: {
+            code: 'NOT_FOUND',
+            message: 'Canonical ticket not found.',
+            correlationId: (req as AuthenticatedRequest).correlationId,
+          },
+        });
+        return;
+      }
+
+      const canonicalDuplicateOf = await getDuplicateOf(sql, canonical_ticket_id);
+      if (canonicalDuplicateOf !== null) {
+        res.status(422).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'The canonical ticket is itself a duplicate.',
+            correlationId: (req as AuthenticatedRequest).correlationId,
+          },
+        });
+        return;
+      }
+
+      const closedStatusId = await getStatusId(sql, 'closed');
+      await closeAsDuplicate(
+        sql,
+        id,
+        canonical_ticket_id,
+        closedStatusId,
+        (req as AuthenticatedRequest).trackerUser.id,
+      );
+      res.status(204).end();
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## Summary
- Migration adds `ready_for_review_at`, `flagged_by`, `duplicate_of` columns to tickets
- `GET /tracker/api/tickets/ready-for-review` — tickets flagged for committee review, committee-only
- `GET /tracker/api/tickets/planning-signal` — open tickets by vote count, filterable by type/domain, committee-only
- `POST /tracker/api/tickets/:id/flag` / `DELETE ...` — moderator/committee flag management
- `POST /tracker/api/tickets/:id/duplicate` — close as duplicate with canonical validation (rejects if canonical is itself a duplicate)
- `ticket.flag_for_review` permission added to moderator and committee roles

## Test plan
- [ ] Typecheck: `pnpm --filter @tracker/server run typecheck`
- [ ] Lint: `pnpm --filter @tracker/server run lint`
- [ ] Unit tests: `pnpm --filter @tracker/server run test:unit`
- [ ] Integration tests (need DB): validate migration, flag/unflag, duplicate closure, ready-for-review list

🤖 Generated with [Claude Code](https://claude.com/claude-code)