### PR TITLE
feat(tracker): full-text search endpoint (TICKET-023)

### DIFF
--- a/tracker/server/src/db/tickets.ts
+++ b/tracker/server/src/db/tickets.ts
@@ -132,3 +132,39 @@ export async function getStatusId(sql: Sql, slug: string): Promise<number> {
   if (!row) throw new Error(`getStatusId: no status with slug '${slug}'`);
   return row.id;
 }
+
+const SEARCH_QUERY_MAX_LENGTH = 500;
+const SEARCH_RESULT_LIMIT = 5;
+
+/** Full-text ticket search using websearch_to_tsquery. Excludes terminal-status tickets. */
+export async function searchTickets(
+  sql: Sql,
+  query: string,
+): Promise<{ ok: true; tickets: TicketSummary[] } | { ok: false; reason: string }> {
+  const q = query.trim();
+  if (!q) return { ok: false, reason: 'query_empty' };
+  if (q.length > SEARCH_QUERY_MAX_LENGTH) return { ok: false, reason: 'query_too_long' };
+
+  const tickets = await sql<TicketSummary[]>`
+    SELECT
+      t.id,
+      t.title,
+      tt.slug AS type_slug,
+      d.slug  AS domain_slug,
+      s.slug  AS status_slug,
+      s.is_terminal,
+      u.display_name AS submitted_by_display_name,
+      t.created_at,
+      t.updated_at
+    FROM tickets t
+    JOIN ticket_types tt ON tt.id = t.type_id
+    JOIN domains      d  ON d.id  = t.domain_id
+    JOIN statuses     s  ON s.id  = t.current_status_id
+    JOIN users        u  ON u.id  = t.submitted_by
+    WHERE s.is_terminal = FALSE
+      AND t.search_vector @@ websearch_to_tsquery('english', ${q})
+    ORDER BY ts_rank(t.search_vector, websearch_to_tsquery('english', ${q})) DESC
+    LIMIT ${SEARCH_RESULT_LIMIT}
+  `;
+  return { ok: true, tickets };
+}

--- a/tracker/server/src/routes/tickets.ts
+++ b/tracker/server/src/routes/tickets.ts
@@ -8,7 +8,7 @@ import type {
   TransitionTicketResponse,
 } from '@tracker/types';
 import { getPool } from '../db/pool.js';
-import { listTickets, getTicketById, getStatusId } from '../db/tickets.js';
+import { listTickets, getTicketById, getStatusId, searchTickets } from '../db/tickets.js';
 import { submitTicket, transitionTicket } from '../services/lifecycle.js';
 import {
   flagTicketForReview,
@@ -124,6 +124,44 @@ router.get(
       const sql = getPool();
       const tickets = await getPlanningSignal(sql, typeId, domainId);
       res.json({ tickets });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** GET /tracker/api/tickets/search?q=<query> — full-text search, non-terminal tickets only */
+router.get(
+  '/search',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const q = req.query['q'];
+    if (typeof q !== 'string' || !q.trim()) {
+      res.status(400).json({
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'q parameter is required.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const sql = getPool();
+      const result = await searchTickets(sql, q);
+      if (!result.ok) {
+        const isLong = result.reason === 'query_too_long';
+        res.status(400).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: isLong ? 'Search query is too long.' : 'q parameter is required.',
+            correlationId: (req as AuthenticatedRequest).correlationId,
+          },
+        });
+        return;
+      }
+      res.json({ tickets: result.tickets });
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
## Summary
- `searchTickets()` uses `websearch_to_tsquery` against the `search_vector` generated column (migration 011)
- `GET /tracker/api/tickets/search?q=<query>` returns up to 5 non-terminal tickets ranked by `ts_rank`
- Returns 400 on empty or overly long query (>500 chars)
- Requires auth; no elevated permission needed

## Test plan
- [ ] Typecheck + lint pass
- [ ] Integration test: term in title returns ticket; terminal ticket excluded; empty query → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)