### PR TITLE
feat(tracker): structured pino logging (TICKET-026)

### DIFF
--- a/tracker/server/src/app.ts
+++ b/tracker/server/src/app.ts
@@ -7,6 +7,7 @@ import { discussionRouter } from './routes/discussion.js';
 import { meRouter } from './routes/me.js';
 import { usersRouter } from './routes/users.js';
 import { lookupsRouter } from './routes/lookups.js';
+import { logger } from './logger.js';
 
 export function createApp() {
   const app = express();
@@ -57,7 +58,7 @@ export function createApp() {
   app.use((err: unknown, req: Request, res: Response, _next: NextFunction) => {
     const correlationId =
       (req as Request & { correlationId?: string }).correlationId ?? randomUUID();
-    console.error({ correlationId, err }, 'Unhandled tracker error');
+    logger.error({ correlationId, err }, 'Unhandled tracker error');
     const body: TrackerErrorResponse = {
       error: {
         code: 'INTERNAL_ERROR',

--- a/tracker/server/src/index.ts
+++ b/tracker/server/src/index.ts
@@ -2,11 +2,12 @@ import './env.js'; // validate env first — crashes fast if misconfigured
 import { env } from './env.js';
 import { createApp } from './app.js';
 import { closePool } from './db/pool.js';
+import { logger } from './logger.js';
 
 const app = createApp();
 
 const server = app.listen(env.TRACKER_PORT, () => {
-  console.log(`[tracker] server listening on port ${env.TRACKER_PORT}`);
+  logger.info({ port: env.TRACKER_PORT }, 'tracker server listening');
 });
 
 function shutdown() {

--- a/tracker/server/src/logger.ts
+++ b/tracker/server/src/logger.ts
@@ -1,0 +1,12 @@
+import pino from 'pino';
+
+/**
+ * Shared pino logger for the tracker service.
+ * All log output includes service: "tracker" for filtering.
+ * No user-facing data (display names, usernames) should appear in log messages — use UUIDs only.
+ */
+export const logger = pino({
+  name: 'tracker',
+  level: process.env['TRACKER_LOG_LEVEL'] ?? 'info',
+  base: { service: 'tracker' },
+});

--- a/tracker/server/src/services/discord.ts
+++ b/tracker/server/src/services/discord.ts
@@ -2,6 +2,7 @@ import type { Sql } from 'postgres';
 import type { NotificationEventType } from '@tracker/types';
 import { env } from '../env.js';
 import { logDiscordDelivery } from '../db/discord.js';
+import { logger } from '../logger.js';
 
 /** Shape of the Discord webhook payload sent to the mod channel. */
 interface WebhookPayload {
@@ -102,9 +103,9 @@ export async function sendDiscordWebhook(
     const error = err instanceof Error ? err.message : String(err);
     await logDiscordDelivery(sql, { eventId, status: 'failure', error: error.slice(0, 500) }).catch(
       (logErr) => {
-        console.error({ ticketId, eventType, logErr }, 'Failed to log Discord delivery failure');
+        logger.error({ ticketId, eventType, logErr }, 'Failed to log Discord delivery failure');
       },
     );
-    console.error({ ticketId, eventType, err }, 'Discord webhook dispatch failed');
+    logger.error({ ticketId, eventType, err }, 'Discord webhook dispatch failed');
   }
 }

--- a/tracker/server/src/services/lifecycle.ts
+++ b/tracker/server/src/services/lifecycle.ts
@@ -2,6 +2,7 @@ import type { Sql } from 'postgres';
 import type { CreateTicketInput } from '../db/tickets.js';
 import { getStatusId } from '../db/tickets.js';
 import { fanoutNotification } from './notifications.js';
+import { logger } from '../logger.js';
 
 /**
  * Submits a new ticket.
@@ -53,6 +54,7 @@ export async function submitTicket(
   // Fanout is fire-and-continue — notification failure does not fail the submission
   void fanoutNotification(sql, ticket.id, submittedBy, 'status_changed');
 
+  logger.info({ ticketId: ticket.id, submittedBy }, 'ticket.submitted');
   return { id: ticket.id };
 }
 
@@ -115,6 +117,11 @@ export async function transitionTicket(
     INSERT INTO ticket_status_history (ticket_id, from_status_id, to_status_id, changed_by, resolution_note)
     VALUES (${ticketId}, ${fromId}, ${toId}, ${changedBy}, ${resolutionNote ?? null})
   `;
+
+  logger.info(
+    { ticketId, fromStatusId: fromId, toStatusId: toId, changedBy, roleSlug },
+    'ticket.transitioned',
+  );
 
   void fanoutNotification(sql, ticketId, changedBy, 'status_changed');
 

--- a/tracker/server/src/services/notifications.ts
+++ b/tracker/server/src/services/notifications.ts
@@ -2,6 +2,7 @@ import type { Sql } from 'postgres';
 import type { NotificationEventType } from '@tracker/types';
 import { recordNotificationEvent } from '../db/notifications.js';
 import { sendDiscordWebhook } from './discord.js';
+import { logger } from '../logger.js';
 
 /**
  * Fans out a notification event to all ticket subscribers (excluding the actor).
@@ -18,7 +19,7 @@ export async function fanoutNotification(
   try {
     await recordNotificationEvent(sql, ticketId, actorId, eventType);
   } catch (err) {
-    console.error({ ticketId, actorId, eventType, err }, 'Notification fanout failed');
+    logger.error({ ticketId, actorId, eventType, err }, 'Notification fanout failed');
   }
 
   // Discord webhook fires after fanout; failures are handled inside sendDiscordWebhook


### PR DESCRIPTION
## Summary
- `logger.ts`: shared pino logger with `service: 'tracker'` context field; level from `TRACKER_LOG_LEVEL` env var
- lifecycle transitions and ticket submission logged at `info` level with ticket/user UUIDs (no PII)
- Integration failure errors in notifications and Discord webhook service use `logger.error`
- Global error handler in `app.ts` uses `logger.error` with `correlationId`
- Server startup uses `logger.info`

## Test plan
- [ ] Typecheck and unit tests pass
- [ ] Manual: start server and verify JSON log output for a ticket submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)