### PR TITLE
feat(tracker): GitHub integration service (TICKET-027)

### DIFF
--- a/tracker/.env.example
+++ b/tracker/.env.example
@@ -64,6 +64,10 @@ NODE_ENV=development
 # GitHub repository name where issues are created.
 # GITHUB_REPO_NAME=
 
+# Public base URL of the tracker site — used in GitHub issue body links.
+# Example: https://hanabichallenges.com
+# TRACKER_BASE_URL=
+
 # ---- Feature configuration (optional with defaults) --------
 
 # Number of days before a ticket in needs_clarification is considered stale.

--- a/tracker/server/migrations/20260327260000_github_integration.sql
+++ b/tracker/server/migrations/20260327260000_github_integration.sql
@@ -1,0 +1,33 @@
+-- Up Migration
+
+-- Records GitHub Issues created from tracker tickets.
+-- One row per ticket (a ticket may only generate one GitHub issue).
+CREATE TABLE github_links (
+  ticket_id   UUID    NOT NULL PRIMARY KEY REFERENCES tickets (id),
+  issue_number INTEGER NOT NULL,
+  issue_url    TEXT    NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Stores every inbound GitHub webhook payload before processing.
+-- The HTTP handler writes pending rows immediately and returns 200;
+-- the background processor updates status after handling.
+CREATE TABLE inbound_webhook_log (
+  id           UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+  github_event TEXT        NOT NULL,
+  payload      JSONB       NOT NULL,
+  status       TEXT        NOT NULL DEFAULT 'pending'
+                           CHECK (status IN ('pending', 'processed', 'ignored', 'failed')),
+  error        TEXT,
+  received_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  processed_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_inbound_webhook_pending ON inbound_webhook_log (status)
+  WHERE status = 'pending';
+
+-- Down Migration
+
+DROP INDEX idx_inbound_webhook_pending;
+DROP TABLE inbound_webhook_log;
+DROP TABLE github_links;

--- a/tracker/server/src/app.ts
+++ b/tracker/server/src/app.ts
@@ -7,10 +7,21 @@ import { discussionRouter } from './routes/discussion.js';
 import { meRouter } from './routes/me.js';
 import { usersRouter } from './routes/users.js';
 import { lookupsRouter } from './routes/lookups.js';
+import { adminRouter } from './routes/admin.js';
 import { logger } from './logger.js';
 
 export function createApp() {
   const app = express();
+
+  // Capture raw body for GitHub webhook HMAC verification before JSON parsing
+  app.use(
+    '/tracker/api/webhooks/github',
+    express.raw({ type: 'application/json', limit: '1mb' }),
+    (req: Request, _res: Response, next: NextFunction) => {
+      (req as Request & { rawBody?: Buffer }).rawBody = req.body as Buffer;
+      next();
+    },
+  );
 
   app.use(express.json({ limit: '1mb' }));
 
@@ -26,6 +37,7 @@ export function createApp() {
   app.use('/tracker/api/me', meRouter);
   app.use('/tracker/api/users', usersRouter);
   app.use('/tracker/api/lookups', lookupsRouter);
+  app.use('/tracker/api', adminRouter);
 
   // Health checks — no auth required
   app.get('/tracker/health', (_req: Request, res: Response) => {

--- a/tracker/server/src/db/github.ts
+++ b/tracker/server/src/db/github.ts
@@ -1,0 +1,139 @@
+import type { Sql } from 'postgres';
+
+export interface GithubLink {
+  ticket_id: string;
+  issue_number: number;
+  issue_url: string;
+  created_at: string;
+}
+
+export interface InboundWebhookLog {
+  id: string;
+  github_event: string;
+  payload: unknown;
+  status: 'pending' | 'processed' | 'ignored' | 'failed';
+  error: string | null;
+  received_at: string;
+  processed_at: string | null;
+}
+
+export async function insertGithubLink(
+  sql: Sql,
+  ticketId: string,
+  issueNumber: number,
+  issueUrl: string,
+): Promise<void> {
+  await sql`
+    INSERT INTO github_links (ticket_id, issue_number, issue_url)
+    VALUES (${ticketId}, ${issueNumber}, ${issueUrl})
+    ON CONFLICT (ticket_id) DO NOTHING
+  `;
+}
+
+export async function insertInboundWebhookLog(
+  sql: Sql,
+  githubEvent: string,
+  payload: unknown,
+): Promise<string> {
+  const [row] = await sql<{ id: string }[]>`
+    INSERT INTO inbound_webhook_log (github_event, payload)
+    VALUES (${githubEvent}, ${sql.json(payload as never)})
+    RETURNING id
+  `;
+  if (!row) throw new Error('insertInboundWebhookLog: no row returned');
+  return row.id;
+}
+
+export async function getPendingWebhookLogs(sql: Sql): Promise<InboundWebhookLog[]> {
+  return sql<InboundWebhookLog[]>`
+    SELECT id, github_event, payload, status, error, received_at, processed_at
+    FROM inbound_webhook_log
+    WHERE status = 'pending'
+    ORDER BY received_at
+    LIMIT 50
+  `;
+}
+
+export async function markWebhookLog(
+  sql: Sql,
+  id: string,
+  status: 'processed' | 'ignored' | 'failed',
+  error?: string,
+): Promise<void> {
+  await sql`
+    UPDATE inbound_webhook_log
+    SET status = ${status}, processed_at = now(), error = ${error ?? null}
+    WHERE id = ${id}
+  `;
+}
+
+export interface LinkedOpenTicket {
+  ticket_id: string;
+  ticket_title: string;
+  status_slug: string;
+  issue_number: number;
+  issue_url: string;
+}
+
+export async function getLinkedOpenTickets(sql: Sql): Promise<LinkedOpenTicket[]> {
+  return sql<LinkedOpenTicket[]>`
+    SELECT
+      gl.ticket_id,
+      t.title AS ticket_title,
+      s.slug  AS status_slug,
+      gl.issue_number,
+      gl.issue_url
+    FROM github_links gl
+    JOIN tickets  t ON t.id = gl.ticket_id
+    JOIN statuses s ON s.id = t.current_status_id
+    WHERE s.is_terminal = FALSE
+    ORDER BY gl.created_at DESC
+  `;
+}
+
+export interface FailedWebhook {
+  id: string;
+  github_event: string;
+  error: string | null;
+  received_at: string;
+}
+
+export async function getFailedWebhooks(sql: Sql): Promise<FailedWebhook[]> {
+  return sql<FailedWebhook[]>`
+    SELECT id, github_event, error, received_at
+    FROM inbound_webhook_log
+    WHERE status = 'failed'
+    ORDER BY received_at DESC
+    LIMIT 100
+  `;
+}
+
+export interface TicketMissingLink {
+  ticket_id: string;
+  ticket_title: string;
+  status_slug: string;
+}
+
+export async function getTicketsMissingGithubLink(sql: Sql): Promise<TicketMissingLink[]> {
+  return sql<TicketMissingLink[]>`
+    SELECT t.id AS ticket_id, t.title AS ticket_title, s.slug AS status_slug
+    FROM tickets t
+    JOIN statuses s ON s.id = t.current_status_id
+    LEFT JOIN github_links gl ON gl.ticket_id = t.id
+    WHERE s.slug = 'in_review'
+      AND gl.ticket_id IS NULL
+    ORDER BY t.created_at
+  `;
+}
+
+export async function getGithubLinkByTicket(
+  sql: Sql,
+  ticketId: string,
+): Promise<GithubLink | null> {
+  const [row] = await sql<GithubLink[]>`
+    SELECT ticket_id, issue_number, issue_url, created_at
+    FROM github_links
+    WHERE ticket_id = ${ticketId}
+  `;
+  return row ?? null;
+}

--- a/tracker/server/src/env.ts
+++ b/tracker/server/src/env.ts
@@ -19,6 +19,8 @@ const schema = z.object({
   GITHUB_WEBHOOK_SECRET: z.string().optional(),
   GITHUB_REPO_OWNER: z.string().optional(),
   GITHUB_REPO_NAME: z.string().optional(),
+  // Public base URL for the tracker site — used in GitHub issue body links
+  TRACKER_BASE_URL: z.string().url().optional(),
   // Feature configuration — optional with defaults
   STALE_TICKET_DAYS: z.coerce.number().int().positive().default(14),
   COMMENT_EDIT_WINDOW_MINUTES: z.coerce.number().int().positive().default(15),

--- a/tracker/server/src/routes/admin.ts
+++ b/tracker/server/src/routes/admin.ts
@@ -1,0 +1,99 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+import { env } from '../env.js';
+import { getPool } from '../db/pool.js';
+import {
+  getLinkedOpenTickets,
+  getFailedWebhooks,
+  getTicketsMissingGithubLink,
+} from '../db/github.js';
+import {
+  validateGithubSignature,
+  receiveGithubWebhook,
+  processWebhookQueue,
+} from '../services/github.js';
+import { requireTrackerAuth, requirePermission } from '../middleware/auth.js';
+import { logger } from '../logger.js';
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// POST /tracker/api/webhooks/github
+// Validates HMAC-SHA256 signature, stores payload, returns 200 immediately.
+// Background processor runs after response is sent.
+// ---------------------------------------------------------------------------
+router.post('/webhooks/github', async (req: Request, res: Response): Promise<void> => {
+  const secret = env.GITHUB_WEBHOOK_SECRET;
+  if (!secret) {
+    // Integration dormant — still return 200 so GitHub doesn't retry
+    res.status(200).end();
+    return;
+  }
+
+  const signature = req.headers['x-hub-signature-256'] as string | undefined;
+  const rawBody: Buffer = (req as Request & { rawBody?: Buffer }).rawBody ?? Buffer.from('');
+
+  if (!validateGithubSignature(rawBody, signature, secret)) {
+    logger.warn({ signature }, 'github webhook: invalid signature');
+    res.status(401).json({ error: 'Invalid signature' });
+    return;
+  }
+
+  const githubEvent = (req.headers['x-github-event'] as string | undefined) ?? 'unknown';
+
+  const sql = getPool();
+  try {
+    await receiveGithubWebhook(sql, githubEvent, req.body as unknown);
+  } catch (err) {
+    logger.error({ err }, 'github webhook: failed to log payload');
+    // Still return 200 — GitHub should not retry due to our internal errors
+  }
+
+  res.status(200).end();
+
+  // Fire-and-forget processor after response
+  void processWebhookQueue(sql);
+});
+
+// ---------------------------------------------------------------------------
+// GET /tracker/api/admin/reconcile — committee only
+// Checks which in_review tickets are missing github_links rows.
+// ---------------------------------------------------------------------------
+router.get(
+  '/admin/reconcile',
+  requireTrackerAuth,
+  requirePermission('ticket.decide'),
+  async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const sql = getPool();
+      const linked = await getLinkedOpenTickets(sql);
+      const missing = await getTicketsMissingGithubLink(sql);
+      res.json({ linked, missing });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// GET /tracker/api/admin/github-failures — committee only
+// Returns failed inbound webhook log entries and tickets missing github_links.
+// ---------------------------------------------------------------------------
+router.get(
+  '/admin/github-failures',
+  requireTrackerAuth,
+  requirePermission('ticket.decide'),
+  async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const sql = getPool();
+      const [failedWebhooks, ticketsMissingLink] = await Promise.all([
+        getFailedWebhooks(sql),
+        getTicketsMissingGithubLink(sql),
+      ]);
+      res.json({ failed_webhooks: failedWebhooks, tickets_missing_link: ticketsMissingLink });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export { router as adminRouter };

--- a/tracker/server/src/services/github.ts
+++ b/tracker/server/src/services/github.ts
@@ -1,0 +1,196 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+import type { Sql } from 'postgres';
+import { env } from '../env.js';
+import { logger } from '../logger.js';
+import {
+  insertGithubLink,
+  insertInboundWebhookLog,
+  getPendingWebhookLogs,
+  markWebhookLog,
+} from '../db/github.js';
+
+// ---------------------------------------------------------------------------
+// HMAC signature validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates a GitHub webhook HMAC-SHA256 signature.
+ *
+ * @param rawBody   The raw request body buffer
+ * @param signature The value of the `X-Hub-Signature-256` header (e.g. "sha256=abc...")
+ * @param secret    The webhook secret
+ * @returns true if the signature is valid
+ */
+export function validateGithubSignature(
+  rawBody: Buffer,
+  signature: string | undefined,
+  secret: string,
+): boolean {
+  if (!signature?.startsWith('sha256=')) return false;
+  const expected = 'sha256=' + createHmac('sha256', secret).update(rawBody).digest('hex');
+  try {
+    return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Issues API: create an issue
+// ---------------------------------------------------------------------------
+
+interface GithubIssueCreated {
+  number: number;
+  html_url: string;
+}
+
+async function callGithubCreateIssue(
+  title: string,
+  body: string,
+): Promise<GithubIssueCreated | null> {
+  const { GITHUB_BOT_TOKEN, GITHUB_REPO_OWNER, GITHUB_REPO_NAME } = env;
+  if (!GITHUB_BOT_TOKEN || !GITHUB_REPO_OWNER || !GITHUB_REPO_NAME) return null;
+
+  const url = `https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/issues`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${GITHUB_BOT_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({ title, body }),
+  });
+
+  if (response.status === 403 || response.status === 429) {
+    const resetHeader = response.headers.get('x-ratelimit-reset');
+    logger.warn({ resetAt: resetHeader }, 'github: rate limit hit, skipping issue creation');
+    return null;
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    logger.error(
+      { status: response.status, body: errorText.slice(0, 200) },
+      'github: create issue failed',
+    );
+    return null;
+  }
+
+  return response.json() as Promise<GithubIssueCreated>;
+}
+
+/**
+ * Creates a GitHub issue for a ticket that has transitioned to in_review.
+ *
+ * Fire-and-forget from the caller's perspective: failure is logged but never
+ * propagated — the transition itself must already have succeeded.
+ */
+export async function createGithubIssue(
+  sql: Sql,
+  ticketId: string,
+  title: string,
+  trackerUrl: string,
+): Promise<void> {
+  if (!env.GITHUB_BOT_TOKEN) return;
+
+  const body = `**Tracker ticket:** ${trackerUrl}\n\nThis issue was automatically created when the ticket moved to In Review.`;
+
+  try {
+    const issue = await callGithubCreateIssue(title, body);
+    if (!issue) return;
+    await insertGithubLink(sql, ticketId, issue.number, issue.html_url);
+    logger.info({ ticketId, issueNumber: issue.number }, 'github: issue created');
+  } catch (err) {
+    logger.error({ ticketId, err }, 'github: createGithubIssue failed');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inbound webhook receiver (write-only, called from route handler)
+// ---------------------------------------------------------------------------
+
+/**
+ * Persists an inbound webhook payload as `pending` and returns immediately.
+ * Processing happens asynchronously via processWebhookQueue.
+ */
+export async function receiveGithubWebhook(
+  sql: Sql,
+  githubEvent: string,
+  payload: unknown,
+): Promise<void> {
+  await insertInboundWebhookLog(sql, githubEvent, payload);
+}
+
+// ---------------------------------------------------------------------------
+// Background webhook processor
+// ---------------------------------------------------------------------------
+
+interface IssuePayload {
+  action: string;
+  issue: { number: number; html_url: string; state: string };
+  repository: { full_name: string };
+}
+
+async function processOneWebhook(
+  sql: Sql,
+  id: string,
+  githubEvent: string,
+  payload: unknown,
+): Promise<void> {
+  if (githubEvent !== 'issues') {
+    await markWebhookLog(sql, id, 'ignored');
+    return;
+  }
+
+  const p = payload as IssuePayload;
+  const { action } = p;
+
+  // Only handle assigned and closed events per the spec
+  if (action !== 'assigned' && action !== 'closed') {
+    await markWebhookLog(sql, id, 'ignored');
+    return;
+  }
+
+  // Log a committee notification at info level; the committee confirms transitions manually
+  if (action === 'closed') {
+    logger.info(
+      { issueNumber: p.issue.number, repo: p.repository.full_name },
+      'github: issue closed — committee should review and confirm resolution',
+    );
+  } else if (action === 'assigned') {
+    logger.info(
+      { issueNumber: p.issue.number, repo: p.repository.full_name },
+      'github: issue assigned — committee alert for in-progress tracking',
+    );
+  }
+
+  await markWebhookLog(sql, id, 'processed');
+}
+
+/**
+ * Processes all pending inbound webhook log rows.
+ * Designed to run after the HTTP response has been sent.
+ */
+export async function processWebhookQueue(sql: Sql): Promise<void> {
+  let rows;
+  try {
+    rows = await getPendingWebhookLogs(sql);
+  } catch (err) {
+    logger.error({ err }, 'github: failed to fetch pending webhooks');
+    return;
+  }
+
+  for (const row of rows) {
+    try {
+      await processOneWebhook(sql, row.id, row.github_event, row.payload);
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      await markWebhookLog(sql, row.id, 'failed', error.slice(0, 500)).catch((e) => {
+        logger.error({ id: row.id, err: e }, 'github: failed to mark webhook as failed');
+      });
+      logger.error({ id: row.id, err }, 'github: webhook processing failed');
+    }
+  }
+}

--- a/tracker/server/src/services/lifecycle.ts
+++ b/tracker/server/src/services/lifecycle.ts
@@ -2,6 +2,8 @@ import type { Sql } from 'postgres';
 import type { CreateTicketInput } from '../db/tickets.js';
 import { getStatusId } from '../db/tickets.js';
 import { fanoutNotification } from './notifications.js';
+import { createGithubIssue } from './github.js';
+import { env } from '../env.js';
 import { logger } from '../logger.js';
 
 /**
@@ -82,9 +84,10 @@ export async function transitionTicket(
   };
 
   // Read current state and validate in one query (no FOR UPDATE — acceptable at this scale)
-  const [row] = await sql<CheckRow[]>`
+  const [row] = await sql<(CheckRow & { ticket_title: string })[]>`
     SELECT
       t.current_status_id,
+      t.title AS ticket_title,
       s_from.is_terminal,
       s_to.id AS to_id,
       EXISTS (
@@ -107,6 +110,7 @@ export async function transitionTicket(
 
   const toId = row.to_id;
   const fromId = row.current_status_id;
+  const ticketTitle = row.ticket_title;
 
   // Apply update and history record in one CTE (atomic)
   await sql`
@@ -124,6 +128,13 @@ export async function transitionTicket(
   );
 
   void fanoutNotification(sql, ticketId, changedBy, 'status_changed');
+
+  // Create a GitHub issue when a ticket moves to in_review
+  if (toStatusSlug === 'in_review') {
+    const base = env.TRACKER_BASE_URL ?? '';
+    const trackerUrl = `${base}/tracker/tickets/${ticketId}`;
+    void createGithubIssue(sql, ticketId, ticketTitle, trackerUrl);
+  }
 
   return { ok: true };
 }

--- a/tracker/server/tests/unit/github.test.ts
+++ b/tracker/server/tests/unit/github.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'crypto';
+
+// Set required env vars before importing the service
+process.env.TRACKER_DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+
+const { validateGithubSignature } = await import('../../src/services/github.js');
+
+const SECRET = 'test-secret-value';
+
+function makeSignature(body: Buffer, secret: string): string {
+  return 'sha256=' + createHmac('sha256', secret).update(body).digest('hex');
+}
+
+describe('validateGithubSignature', () => {
+  it('returns true for a valid signature', () => {
+    const body = Buffer.from(JSON.stringify({ action: 'opened' }));
+    const sig = makeSignature(body, SECRET);
+    expect(validateGithubSignature(body, sig, SECRET)).toBe(true);
+  });
+
+  it('returns false for a tampered body', () => {
+    const body = Buffer.from(JSON.stringify({ action: 'opened' }));
+    const sig = makeSignature(body, SECRET);
+    const tamperedBody = Buffer.from(JSON.stringify({ action: 'closed' }));
+    expect(validateGithubSignature(tamperedBody, sig, SECRET)).toBe(false);
+  });
+
+  it('returns false for a wrong secret', () => {
+    const body = Buffer.from(JSON.stringify({ action: 'opened' }));
+    const sig = makeSignature(body, 'wrong-secret');
+    expect(validateGithubSignature(body, sig, SECRET)).toBe(false);
+  });
+
+  it('returns false when signature header is missing', () => {
+    const body = Buffer.from('{}');
+    expect(validateGithubSignature(body, undefined, SECRET)).toBe(false);
+  });
+
+  it('returns false when signature lacks sha256= prefix', () => {
+    const body = Buffer.from('{}');
+    const raw = createHmac('sha256', SECRET).update(body).digest('hex');
+    expect(validateGithubSignature(body, raw, SECRET)).toBe(false);
+  });
+
+  it('returns false for an empty body when signature was computed on non-empty body', () => {
+    const realBody = Buffer.from('{"action":"opened"}');
+    const sig = makeSignature(realBody, SECRET);
+    expect(validateGithubSignature(Buffer.from(''), sig, SECRET)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `github_links` and `inbound_webhook_log` database tables (new migration)
- `createGithubIssue` service function: calls GitHub API when a ticket transitions to `in_review`, writes a `github_links` row on success; failure is logged but never propagates
- `POST /tracker/api/webhooks/github`: validates HMAC-SHA256 signature, stores payload as `pending`, returns 200 immediately, then runs background processor
- `GET /tracker/api/admin/reconcile` (committee): returns linked open tickets and any `in_review` tickets missing a github_links row
- `GET /tracker/api/admin/github-failures` (committee): returns failed webhook log entries and tickets missing github_links
- Adds `TRACKER_BASE_URL` env var for constructing tracker links in GitHub issue bodies
- 6 unit tests covering HMAC signature validation (valid, tampered body, wrong secret, missing header, bad prefix, empty body)

## Test plan
- [ ] Trigger `in_review` transition on a ticket with GitHub env vars set — verify `github_links` row created
- [ ] POST to webhook endpoint with invalid signature — verify 401
- [ ] POST to webhook endpoint with valid signature — verify 200, `inbound_webhook_log` row inserted
- [ ] GET `/admin/reconcile` as committee — verify response shape
- [ ] Run unit tests: `pnpm --filter @tracker/server run test:unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)