### PR TITLE
feat(tracker): deployment configuration for Render (TICKET-048)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,10 @@ services:
   # ---------------------------------------------------------------------------
   # Production — web (static)
   #
+  # Serves both the main site and the tracker client (merged into /tracker/).
   # Rewrites /api/* and /ws/* to the production API.
+  # Rewrites /tracker/api/* to the tracker API service.
+  # Rewrites /tracker/* to the tracker client SPA's index.html.
   # No preview environments — prod is only deployed from main.
   # ---------------------------------------------------------------------------
   - type: web
@@ -13,7 +16,7 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
-    buildCommand: COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/web... && pnpm -C apps/web run build
+    buildCommand: bash scripts/build-with-tracker.sh
     staticPublishPath: ./apps/web/dist
     domains:
       - hanabi-challenges.com
@@ -25,6 +28,15 @@ services:
       - type: rewrite
         source: /ws/*
         destination: wss://api.hanabi-challenges.com/ws/*
+      - type: rewrite
+        source: /tracker/api/*
+        destination: https://tracker-api.hanabi-challenges.com/tracker/api/*
+      - type: rewrite
+        source: /tracker/health*
+        destination: https://tracker-api.hanabi-challenges.com/tracker/health*
+      - type: rewrite
+        source: /tracker/*
+        destination: /tracker/index.html
       - type: rewrite
         source: /*
         destination: /index.html
@@ -60,6 +72,51 @@ services:
       - api.hanabi-challenges.com
 
   # ---------------------------------------------------------------------------
+  # Production — Tracker API
+  #
+  # Runs the tracker Express server (port 4001) with Discord bot.
+  # Migrations run automatically before the server starts.
+  # No preview environments — prod is only deployed from main.
+  # ---------------------------------------------------------------------------
+  - type: web
+    name: hanabi-challenges-tracker-api-prod
+    runtime: node
+    region: virginia
+    branch: main
+    previews:
+      generation: disabled
+    envVars:
+      - key: NODE_VERSION
+        value: 22.12.0
+      - key: NODE_ENV
+        value: production
+      - key: TRACKER_DATABASE_URL
+        fromDatabase:
+          name: hanabi-challenges-db
+          property: connectionString
+      - key: TRACKER_PORT
+        value: 10000  # Render assigns PORT=10000 for web services
+      - key: TRACKER_LOG_LEVEL
+        value: info
+      - key: TRACKER_BASE_URL
+        value: https://hanabi-challenges.com
+      # GitHub integration — set manually in Render dashboard before go-live
+      # GITHUB_BOT_TOKEN: set in dashboard (sync: false)
+      # GITHUB_WEBHOOK_SECRET: set in dashboard (sync: false)
+      # GITHUB_REPO_OWNER: set in dashboard
+      # GITHUB_REPO_NAME: set in dashboard
+      # Discord integrations — set manually in Render dashboard before go-live
+      # DISCORD_MOD_WEBHOOK_URL: set in dashboard (sync: false)
+      # DISCORD_BOT_TOKEN: set in dashboard (sync: false)
+      # DISCORD_GUILD_ID: set in dashboard
+      # DISCORD_MOD_ROLE_NAME: set in dashboard
+    buildCommand: COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @tracker/server... --filter @tracker/types && pnpm tracker:build
+    startCommand: pnpm tracker:db:migrate && node tracker/server/dist/src/index.js
+    healthCheckPath: /tracker/health
+    domains:
+      - tracker-api.hanabi-challenges.com
+
+  # ---------------------------------------------------------------------------
   # Test — web (static, permanent)
   #
   # No custom domain — uses Render's auto-assigned URL.
@@ -76,7 +133,7 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 22.12.0
-    buildCommand: COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @hanabi-challenges/web... && pnpm -C apps/web run build
+    buildCommand: bash scripts/build-with-tracker.sh
     staticPublishPath: ./apps/web/dist
     routes:
       - type: rewrite
@@ -86,8 +143,49 @@ services:
         source: /ws/*
         destination: wss://hanabi-challenges-api-test.onrender.com/ws/*
       - type: rewrite
+        source: /tracker/api/*
+        destination: https://hanabi-challenges-tracker-api-test.onrender.com/tracker/api/*
+      - type: rewrite
+        source: /tracker/health*
+        destination: https://hanabi-challenges-tracker-api-test.onrender.com/tracker/health*
+      - type: rewrite
+        source: /tracker/*
+        destination: /tracker/index.html
+      - type: rewrite
         source: /*
         destination: /index.html
+
+  # ---------------------------------------------------------------------------
+  # Test — Tracker API (permanent + PR previews)
+  #
+  # Runs the tracker server with migrations on startup.
+  # Preview environments: each open PR gets an isolated tracker API instance.
+  # ---------------------------------------------------------------------------
+  - type: web
+    name: hanabi-challenges-tracker-api-test
+    runtime: node
+    region: virginia
+    branch: main
+    previews:
+      generation: automatic
+    envVars:
+      - key: NODE_VERSION
+        value: 22.12.0
+      - key: NODE_ENV
+        value: test
+      - key: TRACKER_DATABASE_URL
+        fromDatabase:
+          name: hanabi-challenges-db-test
+          property: connectionString
+      - key: TRACKER_PORT
+        value: 10000
+      - key: TRACKER_LOG_LEVEL
+        value: info
+      - key: TRACKER_BASE_URL
+        value: https://hanabi-challenges-test.onrender.com
+    buildCommand: COREPACK_INTEGRITY_KEYS=0 corepack enable && COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate && pnpm install --frozen-lockfile --filter @tracker/server... --filter @tracker/types && pnpm tracker:build
+    startCommand: pnpm tracker:db:migrate && node tracker/server/dist/src/index.js
+    healthCheckPath: /tracker/health
 
   # ---------------------------------------------------------------------------
   # Test — API (permanent + PR previews)

--- a/scripts/build-with-tracker.sh
+++ b/scripts/build-with-tracker.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Builds the main web app and the tracker client, then merges the tracker
+# client's dist into the web app's dist at /tracker/ so they are served
+# as a single static publish.
+
+set -euo pipefail
+
+# Bootstrap pnpm / corepack (idempotent on Render)
+COREPACK_INTEGRITY_KEYS=0 corepack enable
+COREPACK_INTEGRITY_KEYS=0 corepack prepare pnpm@10.31.0 --activate
+
+# Install only what the web app and tracker client need
+pnpm install --frozen-lockfile --filter @hanabi-challenges/web... --filter @tracker/client... --filter @tracker/types
+
+# Build tracker/types first (required by tracker/client)
+pnpm -C tracker/types run build
+
+# Build the main web app and tracker client in parallel
+pnpm -C apps/web run build &
+WEB_PID=$!
+
+pnpm -C tracker/client run build &
+TRACKER_PID=$!
+
+wait $WEB_PID
+wait $TRACKER_PID
+
+# Merge tracker client into the web dist under /tracker/
+mkdir -p apps/web/dist/tracker
+cp -r tracker/client/dist/. apps/web/dist/tracker/

--- a/tracker/PUBLISHING.md
+++ b/tracker/PUBLISHING.md
@@ -118,12 +118,58 @@ When all 48 tickets are complete and the `tracker-main` branch is fully green in
 
 ---
 
+## Deployment Infrastructure (Render)
+
+The tracker runs on [Render](https://render.com), matching the existing site's infrastructure. Two services are added:
+
+### `hanabi-challenges-tracker-api-prod` (Tracker API — Production)
+
+| Setting | Value |
+|---|---|
+| Runtime | Node |
+| Region | Virginia |
+| Branch | `main` |
+| Build | `pnpm install ... && pnpm tracker:build` |
+| Start | `pnpm tracker:db:migrate && node tracker/server/dist/src/index.js` |
+| Health check | `GET /tracker/health` |
+| Domain | `tracker-api.hanabi-challenges.com` |
+
+**Required environment variables** (set in Render dashboard before first deploy):
+- `TRACKER_DATABASE_URL` — from `hanabi-challenges-db` (same Postgres instance as main API)
+- `TRACKER_PORT` — set to `10000` (Render's standard web service port)
+- `TRACKER_BASE_URL` — `https://hanabi-challenges.com`
+- `NODE_ENV` — `production`
+
+**Optional environment variables** (set when activating integrations):
+- `GITHUB_BOT_TOKEN`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_REPO_OWNER`, `GITHUB_REPO_NAME`
+- `DISCORD_MOD_WEBHOOK_URL`, `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`, `DISCORD_MOD_ROLE_NAME`
+
+### `hanabi-challenges-tracker-api-test` (Tracker API — Test)
+
+Same configuration as production but pointing to `hanabi-challenges-db-test`. PR preview environments are enabled — each open PR gets an isolated tracker API instance.
+
+### Static Frontend
+
+The tracker client is built and merged into the main web static service at `/tracker/`. The build command is `bash scripts/build-with-tracker.sh`, which:
+1. Builds the main web app (`apps/web`)
+2. Builds the tracker client (`tracker/client`)
+3. Copies tracker client dist into `apps/web/dist/tracker/`
+
+Routes in the static service forward `/tracker/api/*` and `/tracker/health*` to the tracker API, and serve `/tracker/*` from the tracker client's `index.html`.
+
+### Migration Automation
+
+Migrations run automatically as part of the start command (`pnpm tracker:db:migrate`) before the tracker server starts. If a migration fails, the server process exits and Render marks the deployment failed — no traffic is routed to the broken version.
+
+---
+
 ## Go-Live Activation for Dormant Integrations
 
 These steps require no deployment — configuration only:
 
 - **Discord outbound webhook**: set `DISCORD_MOD_WEBHOOK_URL` in the production environment. The dispatcher activates on the next ticket submission.
 - **Discord bot**: set `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`, and `DISCORD_MOD_ROLE_NAME` in the production environment, then redeploy so the bot process starts. Verify by running `/token` in the Discord server.
+- **GitHub integration**: set `GITHUB_BOT_TOKEN`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_REPO_OWNER`, and `GITHUB_REPO_NAME` in the production environment, then redeploy. Register the webhook in the GitHub repository settings pointing to `https://hanabi-challenges.com/tracker/api/webhooks/github`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Extends `render.yaml` with two new Render web services for the tracker:
  - `hanabi-challenges-tracker-api-prod`: tracker Express server + Discord bot for production; migrations run automatically before server start (`pnpm tracker:db:migrate && node tracker/server/dist/src/index.js`); health check at `GET /tracker/health`; domain `tracker-api.hanabi-challenges.com`
  - `hanabi-challenges-tracker-api-test`: same for test environment, with PR preview environments enabled (each open PR gets an isolated tracker API instance)
- Updates both web static services (prod + test) to use `scripts/build-with-tracker.sh` — builds main web app and tracker client in parallel, then merges tracker client dist into `apps/web/dist/tracker/`
- Adds route rewrites to static services for `/tracker/api/*` → tracker API, `/tracker/health*` → tracker API, `/tracker/*` → tracker client SPA
- Creates `scripts/build-with-tracker.sh` — combined build script
- Extends `tracker/PUBLISHING.md` with a Deployment Infrastructure section documenting services, environment variables, migration automation, and GitHub integration webhook registration

## Design decisions
- Tracker client is merged into the main site's static dist at `/tracker/` rather than hosted as a separate static service — avoids CORS complexity and matches the existing routing pattern
- Tracker API runs as a separate Render web service (not embedded in the main API process) — keeps deployment lifecycles independent
- `TRACKER_PORT=10000` matches Render's standard web service port assignment
- All dormant integrations (Discord bot, GitHub) use the same activation-by-env-var pattern as the existing Discord webhook

## Test plan
- [ ] Verify `scripts/build-with-tracker.sh` runs successfully locally: `bash scripts/build-with-tracker.sh && ls apps/web/dist/tracker/`
- [ ] Confirm `apps/web/dist/tracker/index.html` exists after the build
- [ ] Review `render.yaml` service definitions for correctness before first Render deployment
- [ ] On Render test environment, verify `GET /tracker/health` returns 200 after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)