### PR TITLE
feat(tracker): mod controls — status transitions, metadata editing, soft delete

### DIFF
--- a/apps/web/src/features/feedback/TicketCard.tsx
+++ b/apps/web/src/features/feedback/TicketCard.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Badge, Card, CardBody, Inline, Pill, Text } from '../../design-system';
+import { Badge, Card, CardBody, Grid, Inline, Stack, StatBlock, Text } from '../../design-system';
 import { UserPill } from '../users/UserPill';
 import { STATUS_CONFIG, TYPE_LABELS, DOMAIN_LABELS } from './statusConfig';
 import type { TicketSummary } from './types';
@@ -9,25 +9,12 @@ type TicketCardProps = {
   ticket: TicketSummary;
 };
 
-function Stat({ value, label }: { value: number; label: string }): ReactElement {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-end',
-        whiteSpace: 'nowrap',
-      }}
-    >
-      <Text variant="body" style={{ fontWeight: 700, lineHeight: 1 }}>
-        {value}
-      </Text>
-      <Text variant="caption" style={{ color: 'var(--ds-color-text-muted)', lineHeight: 1.4 }}>
-        {label}
-      </Text>
-    </div>
-  );
-}
+const separatorStyle = {
+  paddingRight: 'var(--ds-space-md)',
+  marginRight: 'var(--ds-space-md)',
+  borderRight: '1px solid var(--ds-color-border)',
+  minWidth: 80,
+} as const;
 
 export function TicketCard({ ticket }: TicketCardProps): ReactElement {
   const navigate = useNavigate();
@@ -45,97 +32,53 @@ export function TicketCard({ ticket }: TicketCardProps): ReactElement {
   return (
     <Card variant="outline" interactive onClick={() => navigate(`/feedback/${ticket.id}`)}>
       <CardBody>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'max-content 1fr',
-            gap: 'var(--ds-space-md)',
-            alignItems: 'start',
-          }}
-        >
-          {/* Left: stats + status badge */}
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'flex-end',
-              gap: 'var(--ds-space-sm)',
-              paddingTop: 2,
-              minWidth: 80,
-            }}
+        <Grid columns="max-content 1fr" gap="none" style={{ gridTemplateRows: '1fr auto' }}>
+          {/* Left top: stats */}
+          <Stack
+            align="center"
+            justify="center"
+            gap="sm"
+            style={{ ...separatorStyle, paddingBottom: 'var(--ds-space-xs)' }}
           >
-            <Stat value={ticket.vote_count ?? 0} label="votes" />
-            <Stat value={ticket.comment_count ?? 0} label="comments" />
-            <Badge tone={statusTone} style={{ whiteSpace: 'nowrap' }}>
-              {statusLabel}
-            </Badge>
-          </div>
+            <StatBlock value={ticket.vote_count ?? 0} label="votes" />
+            <StatBlock value={ticket.comment_count ?? 0} label="comments" />
+          </Stack>
 
-          {/* Right: title, description, tags, attribution */}
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 'var(--ds-space-xs)',
-              minWidth: 0,
-            }}
-          >
-            <Text
-              variant="body"
-              style={{
-                fontWeight: 600,
-                fontSize: 'var(--ds-textScale-1-fontSize)',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
+          {/* Right top: title + description */}
+          <Stack gap="xs" style={{ minWidth: 0, paddingBottom: 'var(--ds-space-xs)' }}>
+            <Text variant="body" weight="semibold" truncate>
               {ticket.title}
             </Text>
-
             {ticket.description && (
-              <Text
-                variant="caption"
-                style={{
-                  color: 'var(--ds-color-text-muted)',
-                  overflow: 'hidden',
-                  display: '-webkit-box',
-                  WebkitLineClamp: 2,
-                  WebkitBoxOrient: 'vertical',
-                }}
-              >
+              <Text variant="caption" lineClamp={2}>
                 {ticket.description}
               </Text>
             )}
+          </Stack>
 
+          {/* Left bottom: status badge */}
+          <Stack align="center" justify="center" style={separatorStyle}>
+            <Badge size="sm" tone={statusTone}>
+              {statusLabel}
+            </Badge>
+          </Stack>
+
+          {/* Right bottom: tags + attribution */}
+          <Inline justify="space-between" align="center" wrap gap="xs">
             <Inline gap="xs" wrap align="center">
-              <Pill size="sm" variant="default">
-                {TYPE_LABELS[ticket.type_slug] ?? ticket.type_slug}
-              </Pill>
-              <Pill size="sm" variant="default">
-                {DOMAIN_LABELS[ticket.domain_slug] ?? ticket.domain_slug}
-              </Pill>
+              <Badge size="sm">{TYPE_LABELS[ticket.type_slug] ?? ticket.type_slug}</Badge>
+              <Badge size="sm">{DOMAIN_LABELS[ticket.domain_slug] ?? ticket.domain_slug}</Badge>
             </Inline>
-
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'flex-end',
-                alignItems: 'center',
-                gap: 'var(--ds-space-xs)',
-              }}
-            >
-              <Text variant="caption" style={{ color: 'var(--ds-color-text-muted)' }}>
-                {date} ·
-              </Text>
+            <Inline gap="xs" align="center">
+              <Text variant="caption">{date} ·</Text>
               <UserPill
                 name={ticket.submitted_by_display_name}
                 color={ticket.submitted_by_color_hex}
                 textColor={ticket.submitted_by_text_color}
               />
-            </div>
-          </div>
-        </div>
+            </Inline>
+          </Inline>
+        </Grid>
       </CardBody>
     </Card>
   );

--- a/apps/web/src/features/feedback/VoteButton.tsx
+++ b/apps/web/src/features/feedback/VoteButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { ReactElement } from 'react';
-import { Button, Inline, MaterialIcon, Text } from '../../design-system';
+import { Button, MaterialIcon, Stack, Text } from '../../design-system';
 import { castVote, removeVote } from './api';
 import type { TicketVoteState } from './types';
 
@@ -8,13 +8,23 @@ type VoteButtonProps = {
   voteState: TicketVoteState;
   token: string | null;
   onVoteChange: (next: TicketVoteState) => void;
+  onLoginRequired: () => void;
 };
 
-export function VoteButton({ voteState, token, onVoteChange }: VoteButtonProps): ReactElement {
+export function VoteButton({
+  voteState,
+  token,
+  onVoteChange,
+  onLoginRequired,
+}: VoteButtonProps): ReactElement {
   const [busy, setBusy] = useState(false);
 
   const handleClick = async () => {
-    if (!token || busy) return;
+    if (!token) {
+      onLoginRequired();
+      return;
+    }
+    if (busy) return;
     setBusy(true);
     try {
       const next = voteState.user_has_voted
@@ -27,20 +37,28 @@ export function VoteButton({ voteState, token, onVoteChange }: VoteButtonProps):
   };
 
   return (
-    <Inline gap="sm" align="center">
+    <Stack gap="xs" align="center">
       <Button
-        variant={voteState.user_has_voted ? 'primary' : 'secondary'}
+        variant="ghost"
         size="sm"
+        icon
         onClick={() => void handleClick()}
-        disabled={!token || busy}
-        aria-label={voteState.user_has_voted ? 'Remove upvote' : 'Upvote'}
+        disabled={busy}
+        aria-label={voteState.user_has_voted ? 'Remove vote' : 'Upvote'}
       >
-        <Inline gap="xs" align="center">
-          <MaterialIcon name="arrow_upward" size={14} />
-          Upvote
-        </Inline>
+        <MaterialIcon
+          name="arrow_shape_up"
+          size={20}
+          style={
+            voteState.user_has_voted
+              ? { color: 'var(--ds-color-accent-strong)', fontVariationSettings: "'FILL' 1" }
+              : undefined
+          }
+        />
       </Button>
-      <Text variant="muted">{voteState.vote_count}</Text>
-    </Inline>
+      <Text variant="body" weight="bold">
+        {voteState.vote_count}
+      </Text>
+    </Stack>
   );
 }

--- a/apps/web/src/features/feedback/api.ts
+++ b/apps/web/src/features/feedback/api.ts
@@ -8,9 +8,13 @@ import type {
   ListCommentsResponse,
   ListTicketsResponse,
   LookupsResponse,
+  TicketPinState,
+  TicketSubscriptionState,
   TicketVoteState,
   TransitionTicketRequest,
   TransitionTicketResponse,
+  UpdateTicketMetadataRequest,
+  UpdateTicketMetadataResponse,
 } from './types';
 
 const BASE = '/tracker/api';
@@ -84,11 +88,64 @@ export function getVoteState(ticketId: string, token?: string | null): Promise<T
 }
 
 export function castVote(ticketId: string, token: string): Promise<TicketVoteState> {
-  return req(`/tickets/${ticketId}/votes`, { method: 'POST' }, token);
+  return req(
+    `/tickets/${ticketId}/votes`,
+    { method: 'POST', body: JSON.stringify({ action: 'add' }) },
+    token,
+  );
 }
 
 export function removeVote(ticketId: string, token: string): Promise<TicketVoteState> {
-  return req(`/tickets/${ticketId}/votes`, { method: 'DELETE' }, token);
+  return req(
+    `/tickets/${ticketId}/votes`,
+    { method: 'POST', body: JSON.stringify({ action: 'remove' }) },
+    token,
+  );
+}
+
+export function getPinState(ticketId: string, token?: string | null): Promise<TicketPinState> {
+  return req(`/tickets/${ticketId}/pins`, {}, token);
+}
+
+export function setPinned(
+  ticketId: string,
+  pinned: boolean,
+  token: string,
+): Promise<TicketPinState> {
+  return req(`/tickets/${ticketId}/pins`, { method: pinned ? 'POST' : 'DELETE' }, token);
+}
+
+export function getSubscriptionState(
+  ticketId: string,
+  token?: string | null,
+): Promise<TicketSubscriptionState> {
+  return req(`/tickets/${ticketId}/subscriptions`, {}, token);
+}
+
+export function setSubscribed(
+  ticketId: string,
+  subscribed: boolean,
+  token: string,
+): Promise<TicketSubscriptionState> {
+  return req(
+    `/tickets/${ticketId}/subscriptions`,
+    { method: subscribed ? 'POST' : 'DELETE' },
+    token,
+  );
+}
+
+export interface MentionUser {
+  id: number;
+  display_name: string;
+  color_hex: string;
+  text_color: string;
+}
+
+export function searchMentionUsers(
+  q: string,
+  token: string | null,
+): Promise<{ users: MentionUser[] }> {
+  return req(`/users/mentions?${new URLSearchParams({ q }).toString()}`, {}, token);
 }
 
 export function transitionStatus(
@@ -97,4 +154,20 @@ export function transitionStatus(
   token: string,
 ): Promise<TransitionTicketResponse> {
   return req(`/tickets/${ticketId}/status`, { method: 'PATCH', body: JSON.stringify(data) }, token);
+}
+
+export function updateTicketMetadata(
+  ticketId: string,
+  data: UpdateTicketMetadataRequest,
+  token: string,
+): Promise<UpdateTicketMetadataResponse> {
+  return req(
+    `/tickets/${ticketId}/metadata`,
+    { method: 'PATCH', body: JSON.stringify(data) },
+    token,
+  );
+}
+
+export function deleteTicket(ticketId: string, token: string): Promise<void> {
+  return req(`/tickets/${ticketId}`, { method: 'DELETE' }, token);
 }

--- a/apps/web/src/features/feedback/statusConfig.ts
+++ b/apps/web/src/features/feedback/statusConfig.ts
@@ -48,8 +48,19 @@ export const REPRODUCIBILITY_LABELS: Record<string, string> = {
   once: 'Once',
 };
 
-// Valid next statuses for each current status (admin-only transitions)
-export const VALID_NEXT_STATUSES: Record<StatusSlug, StatusSlug[]> = {
+// Valid next statuses by role. Committee can do everything; moderators cannot act from in_review.
+const MODERATOR_TRANSITIONS: Record<StatusSlug, StatusSlug[]> = {
+  submitted: ['triaged', 'rejected', 'closed'],
+  triaged: ['in_review', 'rejected', 'closed'],
+  in_review: [],
+  in_progress: ['resolved', 'rejected', 'closed'],
+  decided: ['in_progress', 'resolved', 'rejected', 'closed'],
+  resolved: [],
+  rejected: [],
+  closed: [],
+};
+
+const COMMITTEE_TRANSITIONS: Record<StatusSlug, StatusSlug[]> = {
   submitted: ['triaged', 'rejected', 'closed'],
   triaged: ['in_review', 'rejected', 'closed'],
   in_review: ['decided', 'rejected', 'closed'],
@@ -59,3 +70,11 @@ export const VALID_NEXT_STATUSES: Record<StatusSlug, StatusSlug[]> = {
   rejected: [],
   closed: [],
 };
+
+/** Returns valid next statuses for a given current status, based on main-app roles. */
+export function getValidNextStatuses(current: StatusSlug, roles: string[]): StatusSlug[] {
+  const isCommittee = roles.includes('SUPERADMIN') || roles.includes('SITE_ADMIN');
+  if (isCommittee) return COMMITTEE_TRANSITIONS[current];
+  if (roles.includes('MOD')) return MODERATOR_TRANSITIONS[current];
+  return [];
+}

--- a/apps/web/src/features/feedback/types.ts
+++ b/apps/web/src/features/feedback/types.ts
@@ -106,23 +106,61 @@ export interface TransitionTicketResponse {
   status_slug: StatusSlug;
 }
 
-export interface TicketHistoryEntry {
+export interface MetadataFieldChange {
+  from: string | null;
+  to: string | null;
+}
+
+export interface MetadataChanges {
+  type?: MetadataFieldChange;
+  domain?: MetadataFieldChange;
+  severity?: MetadataFieldChange;
+  reproducibility?: MetadataFieldChange;
+}
+
+export interface StatusHistoryEntry {
+  kind: 'status';
   id: string;
   from_status_slug: StatusSlug | null;
   to_status_slug: StatusSlug;
   changed_by_display_name: string;
+  changed_by_color_hex?: string | null;
+  changed_by_text_color?: string | null;
   resolution_note: string | null;
   created_at: string;
 }
+
+export interface MetadataHistoryEntry {
+  kind: 'metadata';
+  id: string;
+  changed_by_display_name: string;
+  changed_by_color_hex?: string | null;
+  changed_by_text_color?: string | null;
+  changes: MetadataChanges;
+  created_at: string;
+}
+
+export type TicketHistoryEntry = StatusHistoryEntry | MetadataHistoryEntry;
 
 export interface GetTicketHistoryResponse {
   history: TicketHistoryEntry[];
 }
 
+export interface UpdateTicketMetadataRequest {
+  type_slug?: TicketTypeSlug;
+  domain_slug?: DomainSlug;
+  severity?: BugSeverity | null;
+  reproducibility?: BugReproducibility | null;
+}
+
+export type UpdateTicketMetadataResponse = TicketDetail;
+
 export interface TicketComment {
   id: string;
   ticket_id: string;
   author_display_name: string;
+  author_color_hex?: string | null;
+  author_text_color?: string | null;
   body: string;
   is_internal: boolean;
   created_at: string;
@@ -146,4 +184,14 @@ export interface TicketVoteState {
   ticket_id: string;
   vote_count: number;
   user_has_voted: boolean;
+}
+
+export interface TicketPinState {
+  ticket_id: string;
+  is_pinned: boolean;
+}
+
+export interface TicketSubscriptionState {
+  ticket_id: string;
+  is_subscribed: boolean;
 }

--- a/apps/web/src/pages/FeedbackDetailPage.css
+++ b/apps/web/src/pages/FeedbackDetailPage.css
@@ -1,3 +1,5 @@
+/* Responsive layout — kept here because it requires media queries
+   which cannot be expressed via design-system component props alone. */
 .feedback-detail__layout {
   display: grid;
   grid-template-columns: 1fr;
@@ -7,58 +9,120 @@
 
 @media (min-width: 768px) {
   .feedback-detail__layout {
-    grid-template-columns: 1fr 280px;
+    grid-template-columns: 64px 1fr;
+  }
+  /* Actions column is last in DOM (content-first for mobile), but placed left on desktop */
+  .feedback-detail__actions {
+    grid-column: 1;
+    grid-row: 1;
+  }
+  .feedback-detail__content {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  /* Mod layout: actions | content | sidebar */
+  .feedback-detail__layout--mod {
+    grid-template-columns: 64px 1fr 260px;
+  }
+  .feedback-detail__layout--mod .feedback-detail__content {
+    grid-column: 2;
+    grid-row: 1;
+  }
+  .feedback-detail__layout--mod .feedback-detail__mod {
+    grid-column: 3;
+    grid-row: 1;
   }
 }
 
-.feedback-detail__timeline {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ds-space-sm);
+.feedback-detail__mod {
+  border-left: 1px solid var(--ds-color-border);
+  padding-left: var(--ds-space-md);
 }
 
-.feedback-detail__timeline-entry {
+.feedback-detail__danger-btn {
+  color: var(--ds-color-status-danger) !important;
+  border-color: var(--ds-color-status-danger) !important;
+}
+
+.feedback-detail__danger-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--ds-color-status-danger) 8%, transparent) !important;
+}
+
+/* Breadcrumb current-page title: truncate long titles */
+.feedback-detail__breadcrumb-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 320px;
+}
+
+/* ── GitHub-style activity timeline ─────────────────────────────────────── */
+
+.timeline-row {
   display: flex;
-  gap: var(--ds-space-sm);
   align-items: flex-start;
+  gap: var(--ds-space-sm);
+  position: relative;
 }
 
-.feedback-detail__timeline-dot {
-  width: 28px;
-  height: 28px;
+/* Connecting line: runs from this node's center to the top of the next node */
+.timeline-row:not(:last-child) {
+  padding-bottom: var(--ds-space-sm);
+}
+
+.timeline-row:not(:last-child)::before {
+  content: '';
+  position: absolute;
+  top: 12px; /* centre of the 24 px node */
+  bottom: 0;
+  left: 11px; /* centres a 2 px line inside the 24 px node column */
+  width: 2px;
+  background: var(--ds-color-border);
+  z-index: 0;
+}
+
+/* The circular node that sits on the line */
+.timeline-node {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
-  background: var(--ds-color-surface-muted);
-  border: 1px solid var(--ds-color-border);
+  background: var(--ds-color-surface);
+  border: 2px solid var(--ds-color-border);
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-shrink: 0;
-  font-weight: 700;
-  font-size: var(--ds-textScale-3-fontSize, 12px);
+  position: relative;
+  z-index: 1;
   color: var(--ds-color-text-muted);
 }
 
-.feedback-detail__timeline-dot--transition {
-  background: var(--ds-color-tone-info-bg);
-  border-color: transparent;
-  color: var(--ds-color-tone-info-text);
-}
-
-.feedback-detail__timeline-body {
+.timeline-content {
   flex: 1;
   min-width: 0;
-  padding-top: 4px;
+  padding-top: 3px; /* nudges inline text to align with node centre */
 }
 
-.feedback-detail__meta-row {
+/* Comment cards and input card */
+.activity-comment {
+  border: 1px solid var(--ds-color-border);
+  border-radius: var(--ds-radius-md);
+  overflow: hidden;
+  /* reset the top-nudge so the card top aligns with the node top */
+  margin-top: -3px;
+}
+
+.activity-comment__header {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: baseline;
-  gap: var(--ds-space-xs);
-  margin-bottom: var(--ds-space-xxs);
+  gap: var(--ds-space-sm);
+  padding: var(--ds-space-xs) var(--ds-space-sm);
+  background: var(--ds-color-surface-muted);
+  border-bottom: 1px solid var(--ds-color-border);
 }
 
-.feedback-detail__comment-text {
-  color: var(--ds-color-text);
-  line-height: var(--ds-typography-lineHeight-relaxed);
+.activity-comment__body {
+  padding: var(--ds-space-sm);
 }

--- a/apps/web/src/pages/FeedbackDetailPage.tsx
+++ b/apps/web/src/pages/FeedbackDetailPage.tsx
@@ -6,12 +6,14 @@ import {
   Button,
   Heading,
   Inline,
+  Input,
   Main,
   MaterialIcon,
   Modal,
   PageContainer,
   PageHeader,
   Section,
+  Select,
   Stack,
   Text,
 } from '../design-system';
@@ -31,6 +33,9 @@ import {
   setSubscribed,
   createComment,
   searchMentionUsers,
+  updateTicketMetadata,
+  deleteTicket,
+  transitionStatus,
 } from '../features/feedback/api';
 import {
   STATUS_CONFIG,
@@ -38,14 +43,22 @@ import {
   DOMAIN_LABELS,
   SEVERITY_LABELS,
   REPRODUCIBILITY_LABELS,
+  getValidNextStatuses,
 } from '../features/feedback/statusConfig';
 import type {
   TicketDetail,
   TicketHistoryEntry,
+  StatusHistoryEntry,
+  MetadataHistoryEntry,
   TicketComment,
   TicketVoteState,
   TicketPinState,
   TicketSubscriptionState,
+  StatusSlug,
+  BugSeverity,
+  BugReproducibility,
+  TicketTypeSlug,
+  DomainSlug,
 } from '../features/feedback/types';
 import './FeedbackDetailPage.css';
 
@@ -68,10 +81,12 @@ function formatDate(iso: string) {
   });
 }
 
+const TERMINAL_STATUSES = new Set<StatusSlug>(['resolved', 'rejected', 'closed']);
+
 export function FeedbackDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { token } = useAuth();
+  const { token, user } = useAuth();
 
   const [ticket, setTicket] = useState<TicketDetail | null>(null);
   const [timeline, setTimeline] = useState<TimelineEntry[]>([]);
@@ -82,6 +97,7 @@ export function FeedbackDetailPage() {
   const [error, setError] = useState<string | null>(null);
 
   const [loginModalOpen, setLoginModalOpen] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
   const [commentBody, setCommentBody] = useState('');
   const [commentBusy, setCommentBusy] = useState(false);
@@ -89,6 +105,24 @@ export function FeedbackDetailPage() {
 
   const [pinBusy, setPinBusy] = useState(false);
   const [subscribeBusy, setSubscribeBusy] = useState(false);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  // Status transition state
+  const [transitionTo, setTransitionTo] = useState<StatusSlug | ''>('');
+  const [resolutionNote, setResolutionNote] = useState('');
+  const [transitionBusy, setTransitionBusy] = useState(false);
+  const [transitionError, setTransitionError] = useState<string | null>(null);
+
+  // Metadata edit state — initialised from ticket on load
+  const [metaTypeSlug, setMetaTypeSlug] = useState<TicketTypeSlug | ''>('');
+  const [metaDomainSlug, setMetaDomainSlug] = useState<DomainSlug | ''>('');
+  const [metaSeverity, setMetaSeverity] = useState<BugSeverity | 'none' | ''>('');
+  const [metaReproducibility, setMetaReproducibility] = useState<BugReproducibility | 'none' | ''>(
+    '',
+  );
+  const [metaBusy, setMetaBusy] = useState(false);
+  const [metaError, setMetaError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!id) return;
@@ -108,12 +142,22 @@ export function FeedbackDetailPage() {
         setVoteState(votes);
         setPinState(pins);
         setSubscriptionState(subs);
+        setMetaTypeSlug(t.type_slug);
+        setMetaDomainSlug(t.domain_slug);
+        setMetaSeverity(t.severity ?? 'none');
+        setMetaReproducibility(t.reproducibility ?? 'none');
       })
       .catch((err: unknown) => {
         setError(err instanceof Error ? err.message : 'Failed to load ticket.');
       })
       .finally(() => setLoading(false));
   }, [id, token]);
+
+  const isMod =
+    user !== null &&
+    (user.roles.includes('SUPERADMIN') ||
+      user.roles.includes('SITE_ADMIN') ||
+      user.roles.includes('MOD'));
 
   const togglePin = async () => {
     if (!token) {
@@ -149,8 +193,6 @@ export function FeedbackDetailPage() {
     ? (q: string) => searchMentionUsers(q, token).then((r) => r.users)
     : undefined;
 
-  // Build a display_name → color map from all loaded user data so that
-  // @mention pills in ticket descriptions and comments render with their colors.
   const mentionColors = useMemo<MentionColorMap>(() => {
     const map: MentionColorMap = {};
     if (ticket) {
@@ -194,6 +236,78 @@ export function FeedbackDetailPage() {
     }
   };
 
+  const submitTransition = async () => {
+    if (!id || !token || !transitionTo || !ticket) return;
+    setTransitionBusy(true);
+    setTransitionError(null);
+    try {
+      await transitionStatus(
+        id,
+        { to_status: transitionTo, resolution_note: resolutionNote.trim() || undefined },
+        token,
+      );
+      const [t, { history }, { comments }] = await Promise.all([
+        getTicket(id),
+        getTicketHistory(id),
+        getTicketComments(id),
+      ]);
+      setTicket(t);
+      setTimeline(buildTimeline(history, comments));
+      setTransitionTo('');
+      setResolutionNote('');
+    } catch (err) {
+      setTransitionError(err instanceof Error ? err.message : 'Failed to transition status.');
+    } finally {
+      setTransitionBusy(false);
+    }
+  };
+
+  const submitMetadata = async () => {
+    if (!id || !token || !ticket) return;
+    setMetaBusy(true);
+    setMetaError(null);
+    try {
+      const updated = await updateTicketMetadata(
+        id,
+        {
+          type_slug: metaTypeSlug as TicketTypeSlug,
+          domain_slug: metaDomainSlug as DomainSlug,
+          severity: metaSeverity === 'none' ? null : (metaSeverity as BugSeverity) || undefined,
+          reproducibility:
+            metaReproducibility === 'none'
+              ? null
+              : (metaReproducibility as BugReproducibility) || undefined,
+        },
+        token,
+      );
+      setTicket(updated);
+      const { history } = await getTicketHistory(id);
+      setTimeline((prev) => {
+        const comments = prev
+          .filter((e) => e.kind === 'comment')
+          .map((e) => e.data as TicketComment);
+        return buildTimeline(history, comments);
+      });
+    } catch (err) {
+      setMetaError(err instanceof Error ? err.message : 'Failed to update metadata.');
+    } finally {
+      setMetaBusy(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!id || !token) return;
+    setDeleteBusy(true);
+    setDeleteError(null);
+    try {
+      await deleteTicket(id, token);
+      navigate('/feedback');
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete ticket.');
+      setDeleteBusy(false);
+    }
+  };
+
   if (loading) {
     return (
       <Main>
@@ -226,21 +340,19 @@ export function FeedbackDetailPage() {
     tone: 'neutral' as const,
   };
 
+  const validNextStatuses = user ? getValidNextStatuses(ticket.status_slug, user.roles) : [];
+
+  const needsResolutionNote = transitionTo ? TERMINAL_STATUSES.has(transitionTo) : false;
+
   return (
     <Main>
       <PageContainer>
         <Section paddingY="lg" baseLevel={1}>
           <Stack gap="sm">
-            {/* Back nav */}
-            <Button variant="ghost" size="sm" onClick={() => navigate('/feedback')}>
-              <Inline gap="xxs" align="center">
-                <MaterialIcon name="chevron_left" size={14} />
-                Feedback
-              </Inline>
-            </Button>
-
-            <div className="feedback-detail__layout">
-              {/* Content column — right on desktop, top on mobile */}
+            <div
+              className={`feedback-detail__layout${isMod ? ' feedback-detail__layout--mod' : ''}`}
+            >
+              {/* Content column */}
               <div className="feedback-detail__content">
                 <Stack gap="md">
                   {/* Title + status badge */}
@@ -249,41 +361,26 @@ export function FeedbackDetailPage() {
                     actions={<Badge tone={statusTone}>{statusLabel}</Badge>}
                   />
 
-                  {/* Description — rendered as markdown */}
+                  {/* Description */}
                   <MarkdownRenderer markdown={ticket.description} mentionColors={mentionColors} />
 
-                  {/* Metadata: type/domain/severity badges left, attribution right */}
-                  <Inline justify="space-between" align="center" wrap>
-                    <Inline gap="xs" align="center" wrap>
-                      <Badge size="sm">{TYPE_LABELS[ticket.type_slug] ?? ticket.type_slug}</Badge>
+                  {/* Metadata badges */}
+                  <Inline gap="xs" align="center" wrap>
+                    <Badge size="sm">{TYPE_LABELS[ticket.type_slug] ?? ticket.type_slug}</Badge>
+                    <Badge size="sm">
+                      {DOMAIN_LABELS[ticket.domain_slug] ?? ticket.domain_slug}
+                    </Badge>
+                    {ticket.severity ? (
+                      <Badge size="sm">{SEVERITY_LABELS[ticket.severity] ?? ticket.severity}</Badge>
+                    ) : null}
+                    {ticket.reproducibility ? (
                       <Badge size="sm">
-                        {DOMAIN_LABELS[ticket.domain_slug] ?? ticket.domain_slug}
+                        {REPRODUCIBILITY_LABELS[ticket.reproducibility] ?? ticket.reproducibility}
                       </Badge>
-                      {ticket.severity ? (
-                        <Badge size="sm">
-                          {SEVERITY_LABELS[ticket.severity] ?? ticket.severity}
-                        </Badge>
-                      ) : null}
-                      {ticket.reproducibility ? (
-                        <Badge size="sm">
-                          {REPRODUCIBILITY_LABELS[ticket.reproducibility] ?? ticket.reproducibility}
-                        </Badge>
-                      ) : null}
-                    </Inline>
-                    <Inline gap="xs" align="center">
-                      <UserPill
-                        name={ticket.submitted_by_display_name}
-                        color={ticket.submitted_by_color_hex}
-                        textColor={ticket.submitted_by_text_color}
-                      />
-                      <Text variant="caption">{formatDate(ticket.created_at)}</Text>
-                      {ticket.updated_at !== ticket.created_at ? (
-                        <Text variant="caption">(updated {formatDate(ticket.updated_at)})</Text>
-                      ) : null}
-                    </Inline>
+                    ) : null}
                   </Inline>
 
-                  {/* Activity timeline — entries + comment box connected by a vertical line */}
+                  {/* Activity timeline */}
                   <div className="activity-timeline">
                     {timeline.map((entry) =>
                       entry.kind === 'history' ? (
@@ -297,7 +394,6 @@ export function FeedbackDetailPage() {
                       ),
                     )}
 
-                    {/* Terminal node: comment input (logged-in) or login prompt */}
                     {token ? (
                       <div className="timeline-row">
                         <div className="timeline-node">
@@ -346,10 +442,9 @@ export function FeedbackDetailPage() {
                 </Stack>
               </div>
 
-              {/* Actions column — left on desktop, bottom on mobile */}
+              {/* Actions column — left mini-rail */}
               <div className="feedback-detail__actions">
                 <Stack gap="md" align="center">
-                  {/* Vote */}
                   {voteState ? (
                     <VoteButton
                       voteState={voteState}
@@ -359,7 +454,6 @@ export function FeedbackDetailPage() {
                     />
                   ) : null}
 
-                  {/* Pin + follow */}
                   <Stack gap="xs" align="center">
                     <Button
                       variant="ghost"
@@ -411,6 +505,124 @@ export function FeedbackDetailPage() {
                 </Stack>
               </div>
 
+              {/* Mod sidebar — right rail, mods only */}
+              {isMod ? (
+                <div className="feedback-detail__mod">
+                  <Stack gap="lg">
+                    {/* Status transition */}
+                    <Stack gap="sm">
+                      <Heading level={5}>Change status</Heading>
+                      <Select
+                        options={validNextStatuses.map((s) => ({
+                          value: s,
+                          label: STATUS_CONFIG[s]?.label ?? s,
+                        }))}
+                        value={transitionTo}
+                        onChange={(v) => {
+                          setTransitionTo(v as StatusSlug);
+                          setResolutionNote('');
+                          setTransitionError(null);
+                        }}
+                        placeholder="Select next status…"
+                        disabled={transitionBusy || validNextStatuses.length === 0}
+                      />
+                      {needsResolutionNote ? (
+                        <Input
+                          multiline
+                          rows={3}
+                          value={resolutionNote}
+                          onChange={(e) => setResolutionNote(e.target.value)}
+                          placeholder="Resolution note (optional)"
+                          disabled={transitionBusy}
+                        />
+                      ) : null}
+                      {transitionError ? <Alert variant="error" message={transitionError} /> : null}
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        onClick={() => void submitTransition()}
+                        disabled={transitionBusy || !transitionTo}
+                      >
+                        {transitionBusy ? 'Applying…' : 'Apply'}
+                      </Button>
+                    </Stack>
+
+                    {/* Metadata edit */}
+                    <Stack gap="sm">
+                      <Heading level={5}>Edit metadata</Heading>
+                      <Select
+                        options={Object.entries(TYPE_LABELS).map(([v, l]) => ({
+                          value: v,
+                          label: l,
+                        }))}
+                        value={metaTypeSlug}
+                        onChange={(v) => setMetaTypeSlug(v as TicketTypeSlug)}
+                        placeholder="Type…"
+                        disabled={metaBusy}
+                      />
+                      <Select
+                        options={Object.entries(DOMAIN_LABELS).map(([v, l]) => ({
+                          value: v,
+                          label: l,
+                        }))}
+                        value={metaDomainSlug}
+                        onChange={(v) => setMetaDomainSlug(v as DomainSlug)}
+                        placeholder="Domain…"
+                        disabled={metaBusy}
+                      />
+                      <Select
+                        options={[
+                          { value: 'none', label: 'None' },
+                          ...Object.entries(SEVERITY_LABELS).map(([v, l]) => ({
+                            value: v,
+                            label: l,
+                          })),
+                        ]}
+                        value={metaSeverity}
+                        onChange={(v) => setMetaSeverity(v as BugSeverity | 'none')}
+                        placeholder="Severity…"
+                        disabled={metaBusy}
+                      />
+                      <Select
+                        options={[
+                          { value: 'none', label: 'None' },
+                          ...Object.entries(REPRODUCIBILITY_LABELS).map(([v, l]) => ({
+                            value: v,
+                            label: l,
+                          })),
+                        ]}
+                        value={metaReproducibility}
+                        onChange={(v) => setMetaReproducibility(v as BugReproducibility | 'none')}
+                        placeholder="Reproducibility…"
+                        disabled={metaBusy}
+                      />
+                      {metaError ? <Alert variant="error" message={metaError} /> : null}
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => void submitMetadata()}
+                        disabled={metaBusy}
+                      >
+                        {metaBusy ? 'Saving…' : 'Save metadata'}
+                      </Button>
+                    </Stack>
+
+                    {/* Delete */}
+                    <Stack gap="sm">
+                      <Heading level={5}>Danger zone</Heading>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="feedback-detail__danger-btn"
+                        onClick={() => setDeleteModalOpen(true)}
+                      >
+                        Delete ticket
+                      </Button>
+                    </Stack>
+                  </Stack>
+                </div>
+              ) : null}
+
               {/* Login prompt modal */}
               <Modal
                 open={loginModalOpen}
@@ -430,6 +642,43 @@ export function FeedbackDetailPage() {
                   </Button>
                 </Inline>
               </Modal>
+
+              {/* Delete confirmation modal */}
+              <Modal
+                open={deleteModalOpen}
+                onClose={() => {
+                  setDeleteModalOpen(false);
+                  setDeleteError(null);
+                }}
+                maxWidth="400px"
+              >
+                <Heading level={3}>Delete ticket?</Heading>
+                <Text variant="body">
+                  This will permanently remove the ticket from the list. This action cannot be
+                  undone.
+                </Text>
+                {deleteError ? <Alert variant="error" message={deleteError} /> : null}
+                <Inline gap="sm">
+                  <Button
+                    variant="outline"
+                    className="feedback-detail__danger-btn"
+                    onClick={() => void confirmDelete()}
+                    disabled={deleteBusy}
+                  >
+                    {deleteBusy ? 'Deleting…' : 'Yes, delete'}
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      setDeleteModalOpen(false);
+                      setDeleteError(null);
+                    }}
+                    disabled={deleteBusy}
+                  >
+                    Cancel
+                  </Button>
+                </Inline>
+              </Modal>
             </div>
           </Stack>
         </Section>
@@ -439,10 +688,15 @@ export function FeedbackDetailPage() {
 }
 
 function HistoryEntry({ entry }: { entry: TicketHistoryEntry }) {
+  if (entry.kind === 'metadata') {
+    return <MetadataHistoryEntryRow entry={entry} />;
+  }
+  return <StatusHistoryEntryRow entry={entry} />;
+}
+
+function StatusHistoryEntryRow({ entry }: { entry: StatusHistoryEntry }) {
   const toLabel = STATUS_CONFIG[entry.to_status_slug]?.label ?? entry.to_status_slug;
-  const action = entry.from_status_slug
-    ? `changed the status to ${toLabel}`
-    : `opened the ticket as ${toLabel}`;
+  const action = entry.from_status_slug ? `changed the status to ${toLabel}` : `opened the ticket`;
   return (
     <div className="timeline-row">
       <div className="timeline-node">
@@ -458,6 +712,50 @@ function HistoryEntry({ entry }: { entry: TicketHistoryEntry }) {
           <Text variant="caption">{action}</Text>
           <Text variant="caption">· {formatDate(entry.created_at)}</Text>
         </Inline>
+        {entry.resolution_note ? (
+          <Text variant="caption" style={{ marginTop: 4 }}>
+            {entry.resolution_note}
+          </Text>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function MetadataHistoryEntryRow({ entry }: { entry: MetadataHistoryEntry }) {
+  const fieldLabels: Record<string, string> = {
+    type: 'type',
+    domain: 'domain',
+    severity: 'severity',
+    reproducibility: 'reproducibility',
+  };
+  const changeDescriptions = Object.entries(entry.changes).map(([field, change]) => {
+    const label = fieldLabels[field] ?? field;
+    const from = change.from ?? 'none';
+    const to = change.to ?? 'none';
+    return `${label}: ${from} → ${to}`;
+  });
+
+  return (
+    <div className="timeline-row">
+      <div className="timeline-node">
+        <MaterialIcon name="edit_note" size={12} />
+      </div>
+      <div className="timeline-content">
+        <Inline gap="xs" align="center">
+          <UserPill
+            name={entry.changed_by_display_name}
+            color={entry.changed_by_color_hex}
+            textColor={entry.changed_by_text_color}
+          />
+          <Text variant="caption">updated metadata</Text>
+          <Text variant="caption">· {formatDate(entry.created_at)}</Text>
+        </Inline>
+        {changeDescriptions.length > 0 ? (
+          <Text variant="caption" style={{ marginTop: 4 }}>
+            {changeDescriptions.join(', ')}
+          </Text>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/pages/FeedbackNewPage.tsx
+++ b/apps/web/src/pages/FeedbackNewPage.tsx
@@ -15,7 +15,8 @@ import {
   Text,
 } from '../design-system';
 import { useAuth } from '../context/AuthContext';
-import { getLookups, createTicket } from '../features/feedback/api';
+import { getLookups, createTicket, searchMentionUsers } from '../features/feedback/api';
+import { MarkdownEditor } from '../ui/MarkdownEditor';
 import {
   DOMAIN_LABELS,
   TYPE_LABELS,
@@ -239,17 +240,18 @@ export function FeedbackNewPage() {
               error={errors.description}
               helperText="Include as much detail as you can: steps to reproduce, expected vs. actual behavior, etc."
             >
-              <Input
-                multiline
+              <MarkdownEditor
                 rows={7}
                 placeholder="Describe the issue or request in detail…"
                 value={description}
-                onChange={(e) => {
-                  setDescription(e.target.value);
+                onChange={(v) => {
+                  setDescription(v);
                   if (errors.description)
                     setErrors((prev) => ({ ...prev, description: undefined }));
                 }}
-                fullWidth
+                onMentionSearch={
+                  token ? (q) => searchMentionUsers(q, token).then((r) => r.users) : undefined
+                }
               />
             </InputContainer>
 

--- a/apps/web/src/ui/MarkdownRenderer.tsx
+++ b/apps/web/src/ui/MarkdownRenderer.tsx
@@ -390,7 +390,7 @@ type ParsedMarkdown = { tree: Root; definitions: DefinitionsMap };
 
 let lastParsed: { markdown: string; parsed: ParsedMarkdown } | null = null;
 function parseMarkdown(markdown: string): ParsedMarkdown {
-  if (lastParsed?.markdown === markdown) return lastParsed.parsed;
+  if (lastParsed !== null && lastParsed.markdown === markdown) return lastParsed.parsed;
 
   const parsedTree = applyTypographyReplacements(
     unified().use(remarkParse).use(remarkGfm).parse(replaceEmojiShortcodes(markdown)) as Root,

--- a/tracker/server/.env.example
+++ b/tracker/server/.env.example
@@ -1,0 +1,73 @@
+# Tracker server environment variables
+# Copy this file to .env and fill in values for local development.
+
+# ---
+# Required
+# ---
+
+# PostgreSQL connection string for the tracker schema.
+# Use a separate database or the same database as the main site with a different schema.
+# Example: postgresql://user:password@localhost:5432/hanabi_tracker
+TRACKER_DATABASE_URL=
+
+# JWT secret shared with the main site — must match apps/api JWT_SECRET.
+# Required for cookie-based auth (hanabi_token) from the main site SPA.
+JWT_SECRET=
+
+# ---
+# Optional with defaults
+# ---
+
+# Max connection pool size (default: 10)
+# TRACKER_DATABASE_POOL_SIZE=10
+
+# Port the tracker server listens on (default: 4001)
+# TRACKER_PORT=4001
+
+# Pino log level: trace | debug | info | warn | error | fatal (default: info)
+# TRACKER_LOG_LEVEL=info
+
+# Set to "true" to enable SSL for the database connection (required in production)
+# TRACKER_DATABASE_SSL=false
+
+# ---
+# Discord integrations (optional — activate at go-live by setting these)
+# ---
+
+# Discord webhook URL for the mod channel. Setting this activates outbound notifications.
+# DISCORD_MOD_WEBHOOK_URL=
+
+# Discord bot token. Setting this (along with DISCORD_GUILD_ID and DISCORD_MOD_ROLE_NAME)
+# activates the bot process. Requires a redeploy after setting.
+# DISCORD_BOT_TOKEN=
+
+# The Discord server/guild ID.
+# DISCORD_GUILD_ID=
+
+# The name of the Discord role that maps to the tracker moderator role.
+# DISCORD_MOD_ROLE_NAME=
+
+# ---
+# GitHub App integration (optional — activate at go-live by setting these)
+# ---
+
+# GitHub App ID (visible on the app settings page).
+# GITHUB_APP_ID=
+
+# GitHub App private key — the full contents of the downloaded .pem file.
+# In a .env file, wrap in double quotes and include literal newlines.
+# GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----
+# ...
+# -----END RSA PRIVATE KEY-----
+# "
+
+# GitHub App installation ID (the number at the end of the installation URL).
+# GITHUB_APP_INSTALLATION_ID=
+
+# HMAC secret used to validate inbound GitHub webhook payloads.
+# Generate with: openssl rand -hex 32
+# GITHUB_WEBHOOK_SECRET=
+
+# Owner and name of the GitHub repo where issues will be created.
+# GITHUB_REPO_OWNER=
+# GITHUB_REPO_NAME=

--- a/tracker/server/migrations/20260329100000_ticket_pins.sql
+++ b/tracker/server/migrations/20260329100000_ticket_pins.sql
@@ -1,0 +1,16 @@
+-- Up Migration
+
+-- Per-user ticket pins. Pinned tickets float to the top of the user's feed.
+CREATE TABLE ticket_pins (
+  ticket_id  UUID        NOT NULL REFERENCES tickets (id),
+  user_id    UUID        NOT NULL REFERENCES users (id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (ticket_id, user_id)
+);
+
+CREATE INDEX idx_ticket_pins_user_id ON ticket_pins (user_id, created_at DESC);
+
+-- Down Migration
+
+DROP INDEX idx_ticket_pins_user_id;
+DROP TABLE ticket_pins;

--- a/tracker/server/migrations/20260330000000_use_public_users.sql
+++ b/tracker/server/migrations/20260330000000_use_public_users.sql
@@ -1,0 +1,221 @@
+-- Up Migration
+-- Replace tracker-owned users table with direct references to public.users.
+-- User identity (display_name, colors) is owned by the main application.
+-- Tracker-specific settings move to tracker_user_settings.
+-- Tracker role assignments move to tracker_role_assignments.
+
+-- ── Step 1: Add new INTEGER columns ─────────────────────────────────────────
+
+ALTER TABLE tickets               ADD COLUMN submitted_by_new        INTEGER;
+ALTER TABLE tickets               ADD COLUMN flagged_by_new          INTEGER;
+ALTER TABLE ticket_types          ADD COLUMN template_updated_by_new INTEGER;
+ALTER TABLE ticket_status_history ADD COLUMN changed_by_new          INTEGER;
+ALTER TABLE ticket_comments       ADD COLUMN author_id_new           INTEGER;
+ALTER TABLE ticket_votes          ADD COLUMN user_id_new             INTEGER;
+ALTER TABLE ticket_subscriptions  ADD COLUMN user_id_new             INTEGER;
+ALTER TABLE notification_events   ADD COLUMN actor_id_new            INTEGER;
+ALTER TABLE user_notifications    ADD COLUMN user_id_new             INTEGER;
+ALTER TABLE discord_identities    ADD COLUMN user_id_new             INTEGER;
+ALTER TABLE ticket_pins           ADD COLUMN user_id_new             INTEGER;
+
+-- ── Step 2: Populate via display_name join ──────────────────────────────────
+
+UPDATE tickets t
+SET submitted_by_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = t.submitted_by;
+
+UPDATE tickets t
+SET flagged_by_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = t.flagged_by;
+
+UPDATE ticket_types tt
+SET template_updated_by_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = tt.template_updated_by;
+
+-- GitHub Bot has no public.users entry; those rows stay NULL (changed_by becomes nullable).
+UPDATE ticket_status_history h
+SET changed_by_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = h.changed_by;
+
+UPDATE ticket_comments c
+SET author_id_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = c.author_id;
+
+UPDATE ticket_votes v
+SET user_id_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = v.user_id;
+
+UPDATE ticket_subscriptions s
+SET user_id_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = s.user_id;
+
+-- GitHub Bot events get NULL actor_id (actor_id becomes nullable).
+UPDATE notification_events e
+SET actor_id_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = e.actor_id;
+
+UPDATE user_notifications n
+SET user_id_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = n.user_id;
+
+UPDATE discord_identities di
+SET user_id_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = di.user_id;
+
+UPDATE ticket_pins tp
+SET user_id_new = pu.id
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.id = tp.user_id;
+
+-- ── Step 3: Drop composite PKs / unique constraints on old columns ───────────
+
+ALTER TABLE ticket_votes         DROP CONSTRAINT ticket_votes_pkey;
+ALTER TABLE ticket_subscriptions DROP CONSTRAINT ticket_subscriptions_pkey;
+ALTER TABLE ticket_pins          DROP CONSTRAINT ticket_pins_pkey;
+
+-- ── Step 4: Drop old UUID columns (cascades associated FKs & constraints) ───
+
+ALTER TABLE tickets               DROP COLUMN submitted_by;
+ALTER TABLE tickets               DROP COLUMN flagged_by;
+ALTER TABLE ticket_types          DROP COLUMN template_updated_by;
+ALTER TABLE ticket_status_history DROP COLUMN changed_by;
+ALTER TABLE ticket_comments       DROP COLUMN author_id;
+ALTER TABLE ticket_votes          DROP COLUMN user_id;
+ALTER TABLE ticket_subscriptions  DROP COLUMN user_id;
+ALTER TABLE notification_events   DROP COLUMN actor_id;
+ALTER TABLE user_notifications    DROP COLUMN user_id;
+ALTER TABLE discord_identities    DROP COLUMN user_id;
+ALTER TABLE ticket_pins           DROP COLUMN user_id;
+
+-- ── Step 5: Rename new columns ───────────────────────────────────────────────
+
+ALTER TABLE tickets               RENAME COLUMN submitted_by_new        TO submitted_by;
+ALTER TABLE tickets               RENAME COLUMN flagged_by_new          TO flagged_by;
+ALTER TABLE ticket_types          RENAME COLUMN template_updated_by_new TO template_updated_by;
+ALTER TABLE ticket_status_history RENAME COLUMN changed_by_new          TO changed_by;
+ALTER TABLE ticket_comments       RENAME COLUMN author_id_new           TO author_id;
+ALTER TABLE ticket_votes          RENAME COLUMN user_id_new             TO user_id;
+ALTER TABLE ticket_subscriptions  RENAME COLUMN user_id_new             TO user_id;
+ALTER TABLE notification_events   RENAME COLUMN actor_id_new            TO actor_id;
+ALTER TABLE user_notifications    RENAME COLUMN user_id_new             TO user_id;
+ALTER TABLE discord_identities    RENAME COLUMN user_id_new             TO user_id;
+ALTER TABLE ticket_pins           RENAME COLUMN user_id_new             TO user_id;
+
+-- ── Step 6: Add NOT NULL where required ─────────────────────────────────────
+
+ALTER TABLE tickets               ALTER COLUMN submitted_by SET NOT NULL;
+ALTER TABLE ticket_comments       ALTER COLUMN author_id    SET NOT NULL;
+ALTER TABLE ticket_votes          ALTER COLUMN user_id      SET NOT NULL;
+ALTER TABLE ticket_subscriptions  ALTER COLUMN user_id      SET NOT NULL;
+ALTER TABLE user_notifications    ALTER COLUMN user_id      SET NOT NULL;
+ALTER TABLE discord_identities    ALTER COLUMN user_id      SET NOT NULL;
+ALTER TABLE ticket_pins           ALTER COLUMN user_id      SET NOT NULL;
+-- changed_by and actor_id are intentionally nullable: system-triggered events have no actor.
+
+-- ── Step 7: Restore composite PKs ────────────────────────────────────────────
+
+ALTER TABLE ticket_votes         ADD PRIMARY KEY (ticket_id, user_id);
+ALTER TABLE ticket_subscriptions ADD PRIMARY KEY (ticket_id, user_id);
+ALTER TABLE ticket_pins          ADD PRIMARY KEY (ticket_id, user_id);
+
+-- ── Step 8: Add FK constraints to public.users ───────────────────────────────
+
+ALTER TABLE tickets ADD CONSTRAINT fk_tickets_submitted_by
+  FOREIGN KEY (submitted_by) REFERENCES public.users (id);
+ALTER TABLE tickets ADD CONSTRAINT fk_tickets_flagged_by
+  FOREIGN KEY (flagged_by) REFERENCES public.users (id);
+ALTER TABLE ticket_types ADD CONSTRAINT fk_ticket_types_template_updated_by
+  FOREIGN KEY (template_updated_by) REFERENCES public.users (id);
+ALTER TABLE ticket_status_history ADD CONSTRAINT fk_history_changed_by
+  FOREIGN KEY (changed_by) REFERENCES public.users (id);
+ALTER TABLE ticket_comments ADD CONSTRAINT fk_comments_author_id
+  FOREIGN KEY (author_id) REFERENCES public.users (id);
+ALTER TABLE ticket_votes ADD CONSTRAINT fk_votes_user_id
+  FOREIGN KEY (user_id) REFERENCES public.users (id);
+ALTER TABLE ticket_subscriptions ADD CONSTRAINT fk_subscriptions_user_id
+  FOREIGN KEY (user_id) REFERENCES public.users (id);
+ALTER TABLE notification_events ADD CONSTRAINT fk_notification_events_actor_id
+  FOREIGN KEY (actor_id) REFERENCES public.users (id);
+ALTER TABLE user_notifications ADD CONSTRAINT fk_user_notifications_user_id
+  FOREIGN KEY (user_id) REFERENCES public.users (id);
+ALTER TABLE discord_identities ADD CONSTRAINT fk_discord_identities_user_id
+  FOREIGN KEY (user_id) REFERENCES public.users (id);
+ALTER TABLE ticket_pins ADD CONSTRAINT fk_ticket_pins_user_id
+  FOREIGN KEY (user_id) REFERENCES public.users (id);
+
+ALTER TABLE discord_identities ADD CONSTRAINT uq_discord_identities_user_id UNIQUE (user_id);
+
+-- ── Step 9: tracker_user_settings (account_status per user) ──────────────────
+
+CREATE TABLE tracker_user_settings (
+  user_id        INTEGER     NOT NULL REFERENCES public.users (id) PRIMARY KEY,
+  account_status TEXT        NOT NULL DEFAULT 'active'
+                 CHECK (account_status IN ('active', 'restricted', 'banned')),
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Migrate non-default account statuses
+INSERT INTO tracker_user_settings (user_id, account_status)
+SELECT pu.id, u.account_status
+FROM users u
+JOIN public.users pu ON pu.display_name = u.display_name
+WHERE u.account_status != 'active'
+  AND u.display_name != 'GitHub Bot';
+
+-- ── Step 10: tracker_role_assignments (replaces user_role_assignments) ────────
+
+CREATE TABLE tracker_role_assignments (
+  id         UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    INTEGER     NOT NULL REFERENCES public.users (id),
+  role_id    SMALLINT    NOT NULL REFERENCES roles (id),
+  source     TEXT        NOT NULL DEFAULT 'manual'
+             CHECK (source IN ('manual', 'discord_sync')),
+  granted_by INTEGER     REFERENCES public.users (id),
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  revoked_at TIMESTAMPTZ,
+  revoked_by INTEGER     REFERENCES public.users (id)
+);
+
+INSERT INTO tracker_role_assignments (id, user_id, role_id, source, granted_at, revoked_at)
+SELECT ura.id, pu.id, ura.role_id, ura.source, ura.granted_at, ura.revoked_at
+FROM user_role_assignments ura
+JOIN users u ON u.id = ura.user_id
+JOIN public.users pu ON pu.display_name = u.display_name;
+
+CREATE UNIQUE INDEX uq_active_tracker_role
+  ON tracker_role_assignments (user_id, role_id)
+  WHERE revoked_at IS NULL;
+
+-- ── Step 11: Drop old tables ──────────────────────────────────────────────────
+
+DROP TABLE user_role_assignments;
+DROP TABLE users;
+
+-- Down Migration
+-- This migration cannot be automatically reversed (UUID → INTEGER conversion is lossy).
+-- To restore: recreate tracker.users from public.users and re-migrate all foreign keys.
+
+DROP TABLE tracker_role_assignments;
+DROP TABLE tracker_user_settings;

--- a/tracker/server/migrations/20260404000000_mod_controls.sql
+++ b/tracker/server/migrations/20260404000000_mod_controls.sql
@@ -1,0 +1,20 @@
+-- Soft delete support for tickets
+ALTER TABLE tickets ADD COLUMN deleted_at TIMESTAMPTZ;
+
+CREATE INDEX idx_tickets_deleted_at
+  ON tickets (deleted_at)
+  WHERE deleted_at IS NOT NULL;
+
+-- Metadata change history (one row per save, changes stored as JSONB)
+-- changes shape: { field: { from: string | null, to: string | null } }
+-- e.g. { "type": { "from": "bug", "to": "feature_request" }, "severity": { "from": "cosmetic", "to": null } }
+CREATE TABLE ticket_metadata_history (
+  id          UUID        NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+  ticket_id   UUID        NOT NULL REFERENCES tickets (id) ON DELETE CASCADE,
+  changed_by  INTEGER     NOT NULL REFERENCES public.users (id),
+  changes     JSONB       NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_metadata_history_ticket_id
+  ON ticket_metadata_history (ticket_id, created_at DESC);

--- a/tracker/server/src/bot/index.ts
+++ b/tracker/server/src/bot/index.ts
@@ -29,7 +29,7 @@ import {
   getPendingRoleGrants,
   markRoleGrantsApplied,
 } from '../db/discord-bot.js';
-import { upsertTrackerUser, resolveUserRole } from '../db/users.js';
+import { findTrackerUser, resolveUserRole } from '../db/users.js';
 
 const { DISCORD_BOT_TOKEN, DISCORD_GUILD_ID, DISCORD_MOD_ROLE_NAME } = env;
 
@@ -93,7 +93,7 @@ async function handleRoleChange(oldMember: GuildMember, newMember: GuildMember):
 
 async function applyPendingGrants(
   discordUserId: string,
-  userId: string,
+  userId: number,
   guild: import('discord.js').Guild,
 ): Promise<void> {
   const modRoleName = DISCORD_MOD_ROLE_NAME!;
@@ -140,8 +140,15 @@ async function handleTokenCommand(
   }
 
   try {
-    // Upsert the tracker user
-    const trackerUser = await upsertTrackerUser(sql, hanabLiveUsername, hanabLiveUsername);
+    // Look up the user in public.users — they must have a hanab.live account first
+    const trackerUser = await findTrackerUser(sql, hanabLiveUsername);
+    if (!trackerUser) {
+      await interaction.reply({
+        content: `No hanab.live account found for **${hanabLiveUsername}**. Please ensure you have a hanab.live account before linking Discord.`,
+        ephemeral: true,
+      });
+      return;
+    }
 
     // Link the Discord identity
     const linkResult = await linkDiscordIdentity(

--- a/tracker/server/src/db/discord-bot.ts
+++ b/tracker/server/src/db/discord-bot.ts
@@ -23,11 +23,11 @@ export async function recordRoleSyncEvent(
  */
 export async function linkDiscordIdentity(
   sql: Sql,
-  userId: string,
+  userId: number,
   discordUserId: string,
   discordUsername: string,
 ): Promise<{ ok: true } | { ok: false; reason: 'already_linked' }> {
-  const rows = await sql<{ user_id: string }[]>`
+  const rows = await sql<{ user_id: number }[]>`
     INSERT INTO discord_identities (user_id, discord_user_id, discord_username)
     VALUES (${userId}, ${discordUserId}, ${discordUsername})
     ON CONFLICT (discord_user_id) DO NOTHING
@@ -73,8 +73,8 @@ export async function markRoleGrantsApplied(sql: Sql, ids: string[]): Promise<vo
 export async function getUserByDiscordId(
   sql: Sql,
   discordUserId: string,
-): Promise<{ user_id: string } | null> {
-  const [row] = await sql<{ user_id: string }[]>`
+): Promise<{ user_id: number } | null> {
+  const [row] = await sql<{ user_id: number }[]>`
     SELECT user_id FROM discord_identities WHERE discord_user_id = ${discordUserId}
   `;
   return row ?? null;

--- a/tracker/server/src/db/discussion.ts
+++ b/tracker/server/src/db/discussion.ts
@@ -1,11 +1,16 @@
 import type { Sql } from 'postgres';
-import type { TicketComment, TicketVoteState } from '@tracker/types';
+import type {
+  TicketComment,
+  TicketPinState,
+  TicketSubscriptionState,
+  TicketVoteState,
+} from '@tracker/types';
 
 /** Inserts a comment and returns its id. */
 export async function insertComment(
   sql: Sql,
   ticketId: string,
-  authorId: string,
+  authorId: number,
   body: string,
   isInternal: boolean,
 ): Promise<{ id: string }> {
@@ -23,6 +28,8 @@ interface CommentRow {
   id: string;
   ticket_id: string;
   author_display_name: string;
+  author_color_hex: string | null;
+  author_text_color: string | null;
   body: string;
   is_internal: boolean;
   created_at: string;
@@ -42,13 +49,15 @@ export async function listComments(
     SELECT
       c.id,
       c.ticket_id,
-      u.display_name AS author_display_name,
+      u.display_name  AS author_display_name,
+      u.color_hex     AS author_color_hex,
+      u.text_color    AS author_text_color,
       c.body,
       c.is_internal,
       c.created_at::TEXT AS created_at,
       c.updated_at::TEXT AS updated_at
     FROM ticket_comments c
-    JOIN users u ON u.id = c.author_id
+    JOIN public.users  u  ON u.id = c.author_id
     WHERE c.ticket_id = ${ticketId}
       AND (${includeInternal} OR NOT c.is_internal)
     ORDER BY c.created_at ASC
@@ -61,16 +70,16 @@ interface VoteRow {
   user_has_voted: boolean;
 }
 
-/** Returns the vote count and whether the given user has voted. */
+/** Returns the vote count and whether the given user has voted. Pass null for unauthenticated callers. */
 export async function getVoteState(
   sql: Sql,
   ticketId: string,
-  userId: string,
+  userId: number | null,
 ): Promise<TicketVoteState> {
   const [row] = await sql<VoteRow[]>`
     SELECT
       COUNT(*)::TEXT AS vote_count,
-      BOOL_OR(user_id = ${userId}) AS user_has_voted
+      COALESCE(BOOL_OR(user_id = ${userId}), false) AS user_has_voted
     FROM ticket_votes
     WHERE ticket_id = ${ticketId}
   `;
@@ -85,7 +94,7 @@ export async function getVoteState(
 export async function addVote(
   sql: Sql,
   ticketId: string,
-  userId: string,
+  userId: number,
 ): Promise<{ inserted: boolean }> {
   const rows = await sql<{ id: string }[]>`
     INSERT INTO ticket_votes (ticket_id, user_id)
@@ -96,11 +105,77 @@ export async function addVote(
   return { inserted: rows.length > 0 };
 }
 
+// ── Pins ──────────────────────────────────────────────────────────────────────
+
+/** Returns whether the given user has pinned the ticket. Pass null for unauthenticated callers. */
+export async function getPinState(
+  sql: Sql,
+  ticketId: string,
+  userId: number | null,
+): Promise<TicketPinState> {
+  if (!userId) return { ticket_id: ticketId, is_pinned: false };
+  const rows = await sql<{ ticket_id: string }[]>`
+    SELECT ticket_id FROM ticket_pins
+    WHERE ticket_id = ${ticketId} AND user_id = ${userId}
+  `;
+  return { ticket_id: ticketId, is_pinned: rows.length > 0 };
+}
+
+/** Pins a ticket for the given user (idempotent). */
+export async function addPin(sql: Sql, ticketId: string, userId: number): Promise<void> {
+  await sql`
+    INSERT INTO ticket_pins (ticket_id, user_id)
+    VALUES (${ticketId}, ${userId})
+    ON CONFLICT (ticket_id, user_id) DO NOTHING
+  `;
+}
+
+/** Unpins a ticket for the given user. */
+export async function removePin(sql: Sql, ticketId: string, userId: number): Promise<void> {
+  await sql`DELETE FROM ticket_pins WHERE ticket_id = ${ticketId} AND user_id = ${userId}`;
+}
+
+// ── Subscriptions ─────────────────────────────────────────────────────────────
+
+/** Returns whether the given user is subscribed to the ticket. Pass null for unauthenticated callers. */
+export async function getSubscriptionState(
+  sql: Sql,
+  ticketId: string,
+  userId: number | null,
+): Promise<TicketSubscriptionState> {
+  if (!userId) return { ticket_id: ticketId, is_subscribed: false };
+  const rows = await sql<{ ticket_id: string }[]>`
+    SELECT ticket_id FROM ticket_subscriptions
+    WHERE ticket_id = ${ticketId} AND user_id = ${userId}
+  `;
+  return { ticket_id: ticketId, is_subscribed: rows.length > 0 };
+}
+
+/** Subscribes a user to a ticket (idempotent). */
+export async function subscribeToTicket(sql: Sql, ticketId: string, userId: number): Promise<void> {
+  await sql`
+    INSERT INTO ticket_subscriptions (ticket_id, user_id)
+    VALUES (${ticketId}, ${userId})
+    ON CONFLICT (ticket_id, user_id) DO NOTHING
+  `;
+}
+
+/** Unsubscribes a user from a ticket. */
+export async function unsubscribeFromTicket(
+  sql: Sql,
+  ticketId: string,
+  userId: number,
+): Promise<void> {
+  await sql`
+    DELETE FROM ticket_subscriptions WHERE ticket_id = ${ticketId} AND user_id = ${userId}
+  `;
+}
+
 /** Removes a vote. Returns false if the user had not voted. */
 export async function removeVote(
   sql: Sql,
   ticketId: string,
-  userId: string,
+  userId: number,
 ): Promise<{ deleted: boolean }> {
   const rows = await sql<{ ticket_id: string }[]>`
     DELETE FROM ticket_votes

--- a/tracker/server/src/db/moderation.ts
+++ b/tracker/server/src/db/moderation.ts
@@ -5,7 +5,7 @@ import type { TicketSummary } from '@tracker/types';
 export async function flagTicketForReview(
   sql: Sql,
   ticketId: string,
-  flaggedById: string,
+  flaggedById: number,
 ): Promise<void> {
   await sql`
     UPDATE tickets
@@ -31,7 +31,7 @@ export async function closeAsDuplicate(
   ticketId: string,
   canonicalTicketId: string,
   closedStatusId: number,
-  changedById: string,
+  changedById: number,
 ): Promise<void> {
   await sql`
     WITH updated AS (
@@ -80,7 +80,7 @@ export async function listReadyForReviewTickets(sql: Sql): Promise<TicketSummary
     JOIN ticket_types tt ON tt.id = t.type_id
     JOIN domains      d  ON d.id  = t.domain_id
     JOIN statuses     s  ON s.id  = t.current_status_id
-    JOIN users        u  ON u.id  = t.submitted_by
+    JOIN public.users u  ON u.id  = t.submitted_by
     WHERE t.ready_for_review_at IS NOT NULL
     ORDER BY t.ready_for_review_at ASC
   `;
@@ -108,7 +108,7 @@ export async function getPlanningSignal(
     JOIN ticket_types tt ON tt.id = t.type_id
     JOIN domains      d  ON d.id  = t.domain_id
     JOIN statuses     s  ON s.id  = t.current_status_id
-    JOIN users        u  ON u.id  = t.submitted_by
+    JOIN public.users u  ON u.id  = t.submitted_by
     LEFT JOIN ticket_votes tv ON tv.ticket_id = t.id
     WHERE s.is_terminal = FALSE
       ${typeId !== undefined ? sql`AND t.type_id = ${typeId}` : sql``}

--- a/tracker/server/src/db/notifications.ts
+++ b/tracker/server/src/db/notifications.ts
@@ -10,7 +10,7 @@ import type { UserNotification, NotificationEventType } from '@tracker/types';
 export async function recordNotificationEvent(
   sql: Sql,
   ticketId: string,
-  actorId: string,
+  actorId: number | null,
   eventType: NotificationEventType,
 ): Promise<void> {
   await sql`
@@ -24,7 +24,7 @@ export async function recordNotificationEvent(
     FROM ticket_subscriptions ts
     CROSS JOIN event
     WHERE ts.ticket_id = ${ticketId}
-      AND ts.user_id  <> ${actorId}
+      AND (${actorId}::INTEGER IS NULL OR ts.user_id <> ${actorId})
     ON CONFLICT (user_id, event_id) DO NOTHING
   `;
 }
@@ -42,7 +42,7 @@ interface NotificationRow {
 /** Returns all notifications for a user, newest first. */
 export async function listUserNotifications(
   sql: Sql,
-  userId: string,
+  userId: number,
 ): Promise<{ notifications: UserNotification[]; unread_count: number }> {
   const rows = await sql<NotificationRow[]>`
     SELECT
@@ -56,7 +56,7 @@ export async function listUserNotifications(
     FROM user_notifications un
     JOIN notification_events ne ON ne.id   = un.event_id
     JOIN tickets              t  ON t.id   = ne.ticket_id
-    JOIN users                u  ON u.id   = ne.actor_id
+    JOIN public.users         u  ON u.id   = ne.actor_id
     WHERE un.user_id = ${userId}
     ORDER BY un.created_at DESC
   `;
@@ -69,7 +69,7 @@ export async function listUserNotifications(
 export async function markNotificationRead(
   sql: Sql,
   notificationId: string,
-  userId: string,
+  userId: number,
 ): Promise<boolean> {
   const rows = await sql<{ id: string }[]>`
     UPDATE user_notifications

--- a/tracker/server/src/db/roles.ts
+++ b/tracker/server/src/db/roles.ts
@@ -9,9 +9,9 @@ import type { RoleSlug } from '@tracker/types';
  */
 export async function assignRole(
   sql: Sql,
-  userId: string,
+  userId: number,
   roleSlug: RoleSlug,
-  grantedBy: string,
+  grantedBy: number,
 ): Promise<{ ok: true } | { ok: false; reason: 'already_assigned' | 'role_not_found' }> {
   const [role] = await sql<{ id: number }[]>`
     SELECT id FROM roles WHERE name = ${roleSlug}
@@ -19,7 +19,7 @@ export async function assignRole(
   if (!role) return { ok: false, reason: 'role_not_found' };
 
   const rows = await sql<{ id: string }[]>`
-    INSERT INTO user_role_assignments (user_id, role_id, granted_by)
+    INSERT INTO tracker_role_assignments (user_id, role_id, granted_by)
     VALUES (${userId}, ${role.id}, ${grantedBy})
     ON CONFLICT DO NOTHING
     RETURNING id
@@ -35,9 +35,9 @@ export async function assignRole(
  */
 export async function revokeRole(
   sql: Sql,
-  userId: string,
+  userId: number,
   roleSlug: RoleSlug,
-  revokedBy: string,
+  revokedBy: number,
 ): Promise<{ ok: true } | { ok: false; reason: 'not_assigned' | 'role_not_found' }> {
   const [role] = await sql<{ id: number }[]>`
     SELECT id FROM roles WHERE name = ${roleSlug}
@@ -45,7 +45,7 @@ export async function revokeRole(
   if (!role) return { ok: false, reason: 'role_not_found' };
 
   const rows = await sql<{ id: string }[]>`
-    UPDATE user_role_assignments
+    UPDATE tracker_role_assignments
     SET revoked_at = now(), revoked_by = ${revokedBy}
     WHERE user_id = ${userId}
       AND role_id = ${role.id}

--- a/tracker/server/src/db/tickets.ts
+++ b/tracker/server/src/db/tickets.ts
@@ -8,6 +8,10 @@ import type {
   TicketSummary,
   TicketDetail,
   TicketHistoryEntry,
+  StatusHistoryEntry,
+  MetadataHistoryEntry,
+  MetadataChanges,
+  UpdateTicketMetadataRequest,
 } from '@tracker/types';
 
 export interface CreateTicketInput {
@@ -27,7 +31,7 @@ export interface TicketRow {
 /** Inserts a ticket row and returns id + current_status_id. */
 export async function insertTicket(
   sql: Sql,
-  submittedBy: string,
+  submittedBy: number,
   currentStatusId: number,
   input: CreateTicketInput,
 ): Promise<TicketRow> {
@@ -72,7 +76,7 @@ interface TicketDetailRow extends TicketSummaryRow {
   reproducibility: BugReproducibility | null;
 }
 
-/** Returns a paginated list of tickets ordered by newest first. */
+/** Returns a paginated list of tickets. Pinned tickets sort first when userId is provided. */
 export async function listTickets(
   sql: Sql,
   opts: {
@@ -81,6 +85,7 @@ export async function listTickets(
     status_slug?: string;
     type_slug?: string;
     domain_slug?: string;
+    userId?: number | null;
   },
 ): Promise<{ tickets: TicketSummary[]; total: number }> {
   const statusFilter = opts.status_slug ? sql`AND s.slug = ${opts.status_slug}` : sql``;
@@ -93,9 +98,14 @@ export async function listTickets(
     JOIN ticket_types tt ON tt.id = t.type_id
     JOIN domains       d  ON d.id  = t.domain_id
     JOIN statuses      s  ON s.id  = t.current_status_id
-    WHERE true ${statusFilter} ${typeFilter} ${domainFilter}
+    WHERE t.deleted_at IS NULL ${statusFilter} ${typeFilter} ${domainFilter}
   `;
   const total = parseInt(countRow?.count ?? '0', 10);
+
+  const pinJoin = opts.userId
+    ? sql`LEFT JOIN ticket_pins tp ON tp.ticket_id = t.id AND tp.user_id = ${opts.userId}`
+    : sql``;
+  const pinOrder = opts.userId ? sql`(tp.user_id IS NOT NULL) DESC,` : sql``;
 
   const rows = await sql<TicketSummaryRow[]>`
     SELECT
@@ -107,20 +117,20 @@ export async function listTickets(
       s.slug         AS status_slug,
       s.is_terminal,
       u.display_name AS submitted_by_display_name,
-      pu.color_hex   AS submitted_by_color_hex,
-      pu.text_color  AS submitted_by_text_color,
+      u.color_hex    AS submitted_by_color_hex,
+      u.text_color   AS submitted_by_text_color,
       (SELECT COUNT(*)::INTEGER FROM ticket_votes tv WHERE tv.ticket_id = t.id) AS vote_count,
       (SELECT COUNT(*)::INTEGER FROM ticket_comments tc WHERE tc.ticket_id = t.id AND NOT tc.is_internal) AS comment_count,
       t.created_at::TEXT AS created_at,
       t.updated_at::TEXT AS updated_at
     FROM tickets t
-    JOIN ticket_types tt ON tt.id = t.type_id
+    JOIN ticket_types  tt ON tt.id = t.type_id
     JOIN domains       d  ON d.id  = t.domain_id
     JOIN statuses      s  ON s.id  = t.current_status_id
-    JOIN users         u  ON u.id  = t.submitted_by
-    LEFT JOIN public.users pu ON pu.display_name = u.display_name
-    WHERE true ${statusFilter} ${typeFilter} ${domainFilter}
-    ORDER BY t.created_at DESC
+    JOIN public.users  u  ON u.id  = t.submitted_by
+    ${pinJoin}
+    WHERE t.deleted_at IS NULL ${statusFilter} ${typeFilter} ${domainFilter}
+    ORDER BY ${pinOrder} t.created_at DESC
     LIMIT  ${opts.limit}
     OFFSET ${opts.offset}
   `;
@@ -140,8 +150,8 @@ export async function getTicketById(sql: Sql, id: string): Promise<TicketDetail 
       s.slug         AS status_slug,
       s.is_terminal,
       u.display_name AS submitted_by_display_name,
-      pu.color_hex   AS submitted_by_color_hex,
-      pu.text_color  AS submitted_by_text_color,
+      u.color_hex    AS submitted_by_color_hex,
+      u.text_color   AS submitted_by_text_color,
       (SELECT COUNT(*)::INTEGER FROM ticket_votes tv WHERE tv.ticket_id = t.id) AS vote_count,
       (SELECT COUNT(*)::INTEGER FROM ticket_comments tc WHERE tc.ticket_id = t.id AND NOT tc.is_internal) AS comment_count,
       t.severity,
@@ -149,14 +159,96 @@ export async function getTicketById(sql: Sql, id: string): Promise<TicketDetail 
       t.created_at::TEXT AS created_at,
       t.updated_at::TEXT AS updated_at
     FROM tickets t
-    JOIN ticket_types tt ON tt.id = t.type_id
+    JOIN ticket_types  tt ON tt.id = t.type_id
     JOIN domains       d  ON d.id  = t.domain_id
     JOIN statuses      s  ON s.id  = t.current_status_id
-    JOIN users         u  ON u.id  = t.submitted_by
-    LEFT JOIN public.users pu ON pu.display_name = u.display_name
+    JOIN public.users  u  ON u.id  = t.submitted_by
     WHERE t.id = ${id}
+      AND t.deleted_at IS NULL
   `;
   return rows[0] ?? null;
+}
+
+/** Soft-deletes a ticket by setting deleted_at. No-op if already deleted. */
+export async function softDeleteTicket(sql: Sql, ticketId: string): Promise<void> {
+  await sql`
+    UPDATE tickets SET deleted_at = now(), updated_at = now()
+    WHERE id = ${ticketId} AND deleted_at IS NULL
+  `;
+}
+
+/** Looks up a ticket_type id by slug. Throws if not found. */
+async function getTypeId(sql: Sql, slug: string): Promise<number> {
+  const rows = await sql<{ id: number }[]>`SELECT id FROM ticket_types WHERE slug = ${slug}`;
+  const row = rows[0];
+  if (!row) throw new Error(`getTypeId: no ticket_type with slug '${slug}'`);
+  return row.id;
+}
+
+/** Looks up a domain id by slug. Throws if not found. */
+async function getDomainId(sql: Sql, slug: string): Promise<number> {
+  const rows = await sql<{ id: number }[]>`SELECT id FROM domains WHERE slug = ${slug}`;
+  const row = rows[0];
+  if (!row) throw new Error(`getDomainId: no domain with slug '${slug}'`);
+  return row.id;
+}
+
+/**
+ * Updates editable metadata fields on a ticket and writes a metadata history record.
+ * Only fields present in the input are updated; unchanged fields are left as-is.
+ * Returns the updated ticket, or null if the ticket does not exist or is deleted.
+ */
+export async function updateTicketMetadata(
+  sql: Sql,
+  ticketId: string,
+  input: UpdateTicketMetadataRequest,
+  changedBy: number,
+): Promise<TicketDetail | null> {
+  const current = await getTicketById(sql, ticketId);
+  if (!current) return null;
+
+  // Compute which fields are actually changing
+  const changes: MetadataChanges = {};
+  if (input.type_slug !== undefined && input.type_slug !== current.type_slug) {
+    changes.type = { from: current.type_slug, to: input.type_slug };
+  }
+  if (input.domain_slug !== undefined && input.domain_slug !== current.domain_slug) {
+    changes.domain = { from: current.domain_slug, to: input.domain_slug };
+  }
+  if (input.severity !== undefined && input.severity !== current.severity) {
+    changes.severity = { from: current.severity, to: input.severity ?? null };
+  }
+  if (input.reproducibility !== undefined && input.reproducibility !== current.reproducibility) {
+    changes.reproducibility = { from: current.reproducibility, to: input.reproducibility ?? null };
+  }
+
+  if (Object.keys(changes).length === 0) return current;
+
+  // Resolve IDs for changed slug fields
+  const newTypeId =
+    changes.type !== undefined ? await getTypeId(sql, input.type_slug as string) : null;
+  const newDomainId =
+    changes.domain !== undefined ? await getDomainId(sql, input.domain_slug as string) : null;
+
+  // Use a CTE to perform the UPDATE + INSERT atomically in one round-trip.
+  const changesJson = JSON.stringify(changes);
+  await sql`
+    WITH updated AS (
+      UPDATE tickets SET
+        type_id         = COALESCE(${newTypeId}, type_id),
+        domain_id       = COALESCE(${newDomainId}, domain_id),
+        severity        = ${changes.severity !== undefined ? (input.severity ?? null) : sql`severity`},
+        reproducibility = ${changes.reproducibility !== undefined ? (input.reproducibility ?? null) : sql`reproducibility`},
+        updated_at      = now()
+      WHERE id = ${ticketId}
+      RETURNING id
+    )
+    INSERT INTO ticket_metadata_history (ticket_id, changed_by, changes)
+    SELECT ${ticketId}, ${changedBy}, ${changesJson}::jsonb
+    FROM updated
+  `;
+
+  return getTicketById(sql, ticketId);
 }
 
 /** Looks up a status id by slug. Throws if not found. */
@@ -194,7 +286,7 @@ export async function searchTickets(
     JOIN ticket_types tt ON tt.id = t.type_id
     JOIN domains      d  ON d.id  = t.domain_id
     JOIN statuses     s  ON s.id  = t.current_status_id
-    JOIN users        u  ON u.id  = t.submitted_by
+    JOIN public.users u  ON u.id  = t.submitted_by
     WHERE s.is_terminal = FALSE
       AND t.search_vector @@ websearch_to_tsquery('english', ${q})
     ORDER BY ts_rank(t.search_vector, websearch_to_tsquery('english', ${q})) DESC
@@ -203,21 +295,43 @@ export async function searchTickets(
   return { ok: true, tickets };
 }
 
-/** Returns the status transition history for a ticket, oldest first. */
+/** Returns the merged status + metadata history for a ticket, oldest first. */
 export async function getTicketHistory(sql: Sql, ticketId: string): Promise<TicketHistoryEntry[]> {
-  return sql<TicketHistoryEntry[]>`
-    SELECT
-      h.id,
-      s_from.slug AS from_status_slug,
-      s_to.slug   AS to_status_slug,
-      u.display_name AS changed_by_display_name,
-      h.resolution_note,
-      h.created_at
-    FROM ticket_status_history h
-    LEFT JOIN statuses s_from ON s_from.id = h.from_status_id
-    JOIN      statuses s_to   ON s_to.id   = h.to_status_id
-    JOIN      users    u      ON u.id       = h.changed_by
-    WHERE h.ticket_id = ${ticketId}
-    ORDER BY h.created_at ASC
-  `;
+  const [statusRows, metadataRows] = await Promise.all([
+    sql<Omit<StatusHistoryEntry, 'kind'>[]>`
+      SELECT
+        h.id,
+        s_from.slug    AS from_status_slug,
+        s_to.slug      AS to_status_slug,
+        u.display_name AS changed_by_display_name,
+        u.color_hex    AS changed_by_color_hex,
+        u.text_color   AS changed_by_text_color,
+        h.resolution_note,
+        h.created_at::TEXT AS created_at
+      FROM ticket_status_history h
+      LEFT JOIN statuses     s_from ON s_from.id = h.from_status_id
+      JOIN      statuses     s_to   ON s_to.id   = h.to_status_id
+      LEFT JOIN public.users u      ON u.id       = h.changed_by
+      WHERE h.ticket_id = ${ticketId}
+    `,
+    sql<Omit<MetadataHistoryEntry, 'kind'>[]>`
+      SELECT
+        m.id,
+        u.display_name AS changed_by_display_name,
+        u.color_hex    AS changed_by_color_hex,
+        u.text_color   AS changed_by_text_color,
+        m.changes,
+        m.created_at::TEXT AS created_at
+      FROM ticket_metadata_history m
+      JOIN public.users u ON u.id = m.changed_by
+      WHERE m.ticket_id = ${ticketId}
+    `,
+  ]);
+
+  const merged: TicketHistoryEntry[] = [
+    ...statusRows.map((r) => ({ kind: 'status' as const, ...r })),
+    ...metadataRows.map((r) => ({ kind: 'metadata' as const, ...r })),
+  ];
+  merged.sort((a, b) => a.created_at.localeCompare(b.created_at));
+  return merged;
 }

--- a/tracker/server/src/db/users.ts
+++ b/tracker/server/src/db/users.ts
@@ -51,19 +51,31 @@ export async function findTrackerUser(
 
 /**
  * Returns the highest-privilege active role for the given user.
- * Defaults to 'community_member' when no explicit assignment exists.
+ * Explicit tracker_role_assignments take precedence; if none exist,
+ * SUPERADMIN/SITE_ADMIN on the main app implicitly maps to 'committee'.
  * Priority: committee > moderator > community_member.
  */
 export async function resolveUserRole(sql: Sql, userId: number): Promise<RoleSlug> {
-  const rows = await sql<{ name: string }[]>`
-    SELECT r.name
-    FROM tracker_role_assignments tra
-    JOIN roles r ON r.id = tra.role_id
-    WHERE tra.user_id = ${userId}
-      AND tra.revoked_at IS NULL
+  const [row] = await sql<{ assignments: string[]; site_roles: string[] }[]>`
+    SELECT
+      COALESCE(
+        ARRAY_AGG(r.name) FILTER (WHERE tra.id IS NOT NULL AND tra.revoked_at IS NULL),
+        '{}'
+      ) AS assignments,
+      COALESCE(u.roles, '{}') AS site_roles
+    FROM public.users u
+    LEFT JOIN tracker_role_assignments tra ON tra.user_id = u.id
+    LEFT JOIN roles r ON r.id = tra.role_id
+    WHERE u.id = ${userId}
+    GROUP BY u.roles
   `;
-  if (rows.some((r) => r.name === 'committee')) return 'committee';
-  if (rows.some((r) => r.name === 'moderator')) return 'moderator';
+  if (!row) return 'community_member';
+  if (row.assignments.includes('committee')) return 'committee';
+  if (row.assignments.includes('moderator')) return 'moderator';
+  // Fall back to main-app roles: SUPERADMIN/SITE_ADMIN → committee
+  if (row.site_roles.includes('SUPERADMIN') || row.site_roles.includes('SITE_ADMIN')) {
+    return 'committee';
+  }
   return 'community_member';
 }
 

--- a/tracker/server/src/env.ts
+++ b/tracker/server/src/env.ts
@@ -4,7 +4,10 @@ import { z } from 'zod';
 dotenv.config();
 
 const schema = z.object({
-  TRACKER_DATABASE_URL: z.string().url('TRACKER_DATABASE_URL must be a valid URL'),
+  TRACKER_DATABASE_URL: z.preprocess(
+    (val) => val ?? process.env['DATABASE_URL'],
+    z.string().url('TRACKER_DATABASE_URL or DATABASE_URL must be a valid URL'),
+  ),
   TRACKER_DATABASE_POOL_SIZE: z.coerce.number().int().min(1).max(100).default(10),
   TRACKER_PORT: z.coerce.number().int().min(1).max(65535).default(4001),
   TRACKER_LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),

--- a/tracker/server/src/middleware/auth.ts
+++ b/tracker/server/src/middleware/auth.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'crypto';
 import jwt from 'jsonwebtoken';
 import type { TrackerUser, TrackerErrorResponse } from '@tracker/types';
 import { getPool } from '../db/pool.js';
-import { upsertTrackerUser, resolveUserRole } from '../db/users.js';
+import { findTrackerUser, resolveUserRole } from '../db/users.js';
 import { env } from '../env.js';
 
 /**
@@ -115,7 +115,12 @@ export async function requireTrackerAuth(
 
   try {
     const sql = getPool();
-    const user = await upsertTrackerUser(sql, hanabLiveUsername, displayName);
+    const user = await findTrackerUser(sql, displayName);
+
+    if (!user) {
+      res.status(401).json(errorResponse('UNAUTHORIZED', 'Authentication required.', req));
+      return;
+    }
 
     if (user.account_status === 'banned' || user.account_status === 'restricted') {
       res
@@ -128,11 +133,76 @@ export async function requireTrackerAuth(
 
     (req as AuthenticatedRequest).trackerUser = {
       id: user.id,
-      hanablive_username: user.hanablive_username,
+      hanablive_username: user.display_name,
       display_name: user.display_name,
       account_status: user.account_status,
       role,
     };
+
+    next();
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * Like requireTrackerAuth, but does not return 401 when no session is present.
+ * Attaches req.trackerUser only when a valid session is found.
+ * Use for endpoints that are publicly readable but auth-aware (e.g. "did I vote?").
+ */
+export async function optionalTrackerAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  const siteUser = (req as Request & { user?: SiteUser }).user;
+
+  const testUsername =
+    process.env['NODE_ENV'] !== 'production' && req.headers
+      ? (req.headers['x-tracker-test-username'] as string | undefined)
+      : undefined;
+
+  let cookieUsername: string | undefined;
+  if (!testUsername && !siteUser?.hanabLiveUsername && env.JWT_SECRET) {
+    const cookieHeader = req.headers?.cookie ?? '';
+    const token = cookieHeader
+      .split(';')
+      .map((c) => c.trim())
+      .find((c) => c.startsWith('hanabi_token='))
+      ?.slice('hanabi_token='.length);
+    if (token) {
+      try {
+        const payload = jwt.verify(token, env.JWT_SECRET) as { displayName?: string };
+        cookieUsername = payload.displayName;
+      } catch {
+        // Invalid or expired token — proceed unauthenticated
+      }
+    }
+  }
+
+  const hanabLiveUsername = testUsername ?? siteUser?.hanabLiveUsername ?? cookieUsername;
+
+  if (!hanabLiveUsername) {
+    next(); // No auth present — proceed without trackerUser
+    return;
+  }
+
+  const displayName = testUsername ?? siteUser?.displayName ?? cookieUsername ?? hanabLiveUsername;
+
+  try {
+    const sql = getPool();
+    const user = await findTrackerUser(sql, displayName);
+
+    if (user && user.account_status !== 'banned' && user.account_status !== 'restricted') {
+      const role = await resolveUserRole(sql, user.id);
+      (req as AuthenticatedRequest).trackerUser = {
+        id: user.id,
+        hanablive_username: user.display_name,
+        display_name: user.display_name,
+        account_status: user.account_status,
+        role,
+      };
+    }
 
     next();
   } catch (err) {

--- a/tracker/server/src/routes/discussion.ts
+++ b/tracker/server/src/routes/discussion.ts
@@ -3,6 +3,8 @@ import type {
   CreateCommentRequest,
   CreateCommentResponse,
   ListCommentsResponse,
+  TicketPinState,
+  TicketSubscriptionState,
   TicketVoteState,
 } from '@tracker/types';
 import { getPool } from '../db/pool.js';
@@ -12,9 +14,16 @@ import {
   getVoteState,
   addVote,
   removeVote,
+  getPinState,
+  addPin,
+  removePin,
+  getSubscriptionState,
+  subscribeToTicket,
+  unsubscribeFromTicket,
 } from '../db/discussion.js';
 import {
   requireTrackerAuth,
+  optionalTrackerAuth,
   requirePermission,
   type AuthenticatedRequest,
 } from '../middleware/auth.js';
@@ -70,6 +79,8 @@ router.post(
         body.trim(),
         isInternal,
       );
+      // Auto-subscribe the commenter so they receive future updates
+      void subscribeToTicket(sql, ticketId, authed.trackerUser.id);
       // Fanout only for public comments — internal notes don't notify community members
       if (!isInternal) {
         void fanoutNotification(sql, ticketId, authed.trackerUser.id, 'comment_added');
@@ -114,28 +125,22 @@ router.get(
   },
 );
 
-/** GET /tracker/api/tickets/:ticketId/votes */
+/** GET /tracker/api/tickets/:ticketId/votes — public; auth-aware for user_has_voted */
 router.get(
   '/votes',
-  requireTrackerAuth,
+  optionalTrackerAuth,
   async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const ticketId = req.params['ticketId'] as string | undefined;
     if (!ticketId) {
-      res.status(404).json({
-        error: {
-          code: 'NOT_FOUND',
-          message: 'Ticket not found.',
-          correlationId: (req as AuthenticatedRequest).correlationId,
-        },
-      });
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Ticket not found.' } });
       return;
     }
 
     try {
       const sql = getPool();
-      const state = await getVoteState(sql, ticketId, (req as AuthenticatedRequest).trackerUser.id);
-      const responseBody: TicketVoteState = state;
-      res.json(responseBody);
+      const userId = (req as Partial<AuthenticatedRequest>).trackerUser?.id ?? null;
+      const state = await getVoteState(sql, ticketId, userId);
+      res.json(state satisfies TicketVoteState);
     } catch (err) {
       next(err);
     }
@@ -185,6 +190,132 @@ router.post(
       const state = await getVoteState(sql, ticketId, userId);
       const responseBody: TicketVoteState = state;
       res.json(responseBody);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** GET /tracker/api/tickets/:ticketId/pins — public; auth-aware for is_pinned */
+router.get(
+  '/pins',
+  optionalTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ticketId = req.params['ticketId'] as string | undefined;
+    if (!ticketId) {
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Ticket not found.' } });
+      return;
+    }
+    try {
+      const sql = getPool();
+      const userId = (req as Partial<AuthenticatedRequest>).trackerUser?.id ?? null;
+      const state = await getPinState(sql, ticketId, userId);
+      res.json(state satisfies TicketPinState);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** POST /tracker/api/tickets/:ticketId/pins — pin a ticket */
+router.post(
+  '/pins',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ticketId = req.params['ticketId'] as string | undefined;
+    if (!ticketId) {
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Ticket not found.' } });
+      return;
+    }
+    try {
+      const sql = getPool();
+      await addPin(sql, ticketId, (req as AuthenticatedRequest).trackerUser.id);
+      const body: TicketPinState = { ticket_id: ticketId, is_pinned: true };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** DELETE /tracker/api/tickets/:ticketId/pins — unpin a ticket */
+router.delete(
+  '/pins',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ticketId = req.params['ticketId'] as string | undefined;
+    if (!ticketId) {
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Ticket not found.' } });
+      return;
+    }
+    try {
+      const sql = getPool();
+      await removePin(sql, ticketId, (req as AuthenticatedRequest).trackerUser.id);
+      const body: TicketPinState = { ticket_id: ticketId, is_pinned: false };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** GET /tracker/api/tickets/:ticketId/subscriptions — public; auth-aware for is_subscribed */
+router.get(
+  '/subscriptions',
+  optionalTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ticketId = req.params['ticketId'] as string | undefined;
+    if (!ticketId) {
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Ticket not found.' } });
+      return;
+    }
+    try {
+      const sql = getPool();
+      const userId = (req as Partial<AuthenticatedRequest>).trackerUser?.id ?? null;
+      const state = await getSubscriptionState(sql, ticketId, userId);
+      res.json(state satisfies TicketSubscriptionState);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** POST /tracker/api/tickets/:ticketId/subscriptions — subscribe to a ticket */
+router.post(
+  '/subscriptions',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ticketId = req.params['ticketId'] as string | undefined;
+    if (!ticketId) {
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Ticket not found.' } });
+      return;
+    }
+    try {
+      const sql = getPool();
+      await subscribeToTicket(sql, ticketId, (req as AuthenticatedRequest).trackerUser.id);
+      const body: TicketSubscriptionState = { ticket_id: ticketId, is_subscribed: true };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** DELETE /tracker/api/tickets/:ticketId/subscriptions — unsubscribe from a ticket */
+router.delete(
+  '/subscriptions',
+  requireTrackerAuth,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ticketId = req.params['ticketId'] as string | undefined;
+    if (!ticketId) {
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: 'Ticket not found.' } });
+      return;
+    }
+    try {
+      const sql = getPool();
+      await unsubscribeFromTicket(sql, ticketId, (req as AuthenticatedRequest).trackerUser.id);
+      const body: TicketSubscriptionState = { ticket_id: ticketId, is_subscribed: false };
+      res.json(body);
     } catch (err) {
       next(err);
     }

--- a/tracker/server/src/routes/templates.ts
+++ b/tracker/server/src/routes/templates.ts
@@ -32,7 +32,7 @@ router.get(
           tt.template_updated_at,
           u.display_name AS updated_by_display_name
         FROM ticket_types tt
-        LEFT JOIN users u ON u.id = tt.template_updated_by
+        LEFT JOIN public.users u ON u.id = tt.template_updated_by
         WHERE tt.slug = ${type_slug}
       `;
 
@@ -144,7 +144,7 @@ router.get(
           tt.template_updated_at,
           u.display_name AS updated_by_display_name
         FROM ticket_types tt
-        LEFT JOIN users u ON u.id = tt.template_updated_by
+        LEFT JOIN public.users u ON u.id = tt.template_updated_by
         ORDER BY tt.sort_order
       `;
       res.json({

--- a/tracker/server/src/routes/test.ts
+++ b/tracker/server/src/routes/test.ts
@@ -22,9 +22,9 @@ interface SeedUser {
  *
  * Wipes all tracker ticket data (tickets, comments, votes, history,
  * notifications) and seeds a set of users with their roles.
- * Users already present are upserted; roles are replaced.
+ * Users are upserted into public.users; tracker_role_assignments are replaced.
  *
- * Returns the seeded users with their UUIDs so tests can reference them
+ * Returns the seeded users with their IDs so tests can reference them
  * by ID in subsequent calls.
  */
 router.post('/seed', async (req: Request, res: Response): Promise<void> => {
@@ -49,41 +49,39 @@ router.post('/seed', async (req: Request, res: Response): Promise<void> => {
     await sql`DELETE FROM tickets`;
     // Wipe role assignments so each seed call starts with a clean role state.
     // Roles are re-assigned below for each seeded user.
-    await sql`DELETE FROM user_role_assignments`;
+    await sql`DELETE FROM tracker_role_assignments`;
 
-    // Upsert each requested user and assign their role.
-    const seeded: { username: string; id: string; role: string }[] = [];
+    // Upsert each requested user into public.users and assign their tracker role.
+    const seeded: { username: string; id: number; role: string }[] = [];
 
     for (const u of users) {
-      const username = u.username;
-      const displayName = u.display_name ?? username;
+      const displayName = u.display_name ?? u.username;
 
-      const [row] = await sql<{ id: string }[]>`
-        INSERT INTO users (hanablive_username, display_name)
-        VALUES (${username}, ${displayName})
-        ON CONFLICT (hanablive_username) DO UPDATE SET display_name = EXCLUDED.display_name
+      const [row] = await sql<{ id: number }[]>`
+        INSERT INTO public.users (display_name)
+        VALUES (${displayName})
+        ON CONFLICT (display_name) DO UPDATE SET display_name = EXCLUDED.display_name
         RETURNING id
       `;
-      if (!row) throw new Error(`seed: failed to upsert user ${username}`);
+      if (!row) throw new Error(`seed: failed to upsert user ${displayName}`);
 
       const userId = row.id;
 
       if (u.role && u.role !== 'community_member') {
-        // Resolve role id
         const [roleRow] = await sql<{ id: number }[]>`
           SELECT id FROM roles WHERE name = ${u.role}
         `;
         if (!roleRow) throw new Error(`seed: unknown role ${u.role}`);
 
         await sql`
-          INSERT INTO user_role_assignments (user_id, role_id, granted_by)
+          INSERT INTO tracker_role_assignments (user_id, role_id, granted_by)
           VALUES (${userId}, ${roleRow.id}, ${userId})
-          ON CONFLICT (user_id, role_id) WHERE revoked_at IS NULL DO NOTHING
+          ON CONFLICT DO NOTHING
         `;
       }
 
       const resolvedRole = u.role ?? 'community_member';
-      seeded.push({ username, id: userId, role: resolvedRole });
+      seeded.push({ username: u.username, id: userId, role: resolvedRole });
     }
 
     res.json({ seeded });
@@ -96,7 +94,7 @@ router.post('/seed', async (req: Request, res: Response): Promise<void> => {
 /**
  * GET /tracker/api/test/user/:username
  *
- * Returns the tracker user record for a given hanabLiveUsername.
+ * Returns the tracker user record for a given display_name.
  * Used by tests to look up user IDs without going through the main auth flow.
  */
 router.get('/user/:username', async (req: Request, res: Response): Promise<void> => {
@@ -108,8 +106,8 @@ router.get('/user/:username', async (req: Request, res: Response): Promise<void>
 
   try {
     const sql = getPool();
-    const [row] = await sql<{ id: string; hanablive_username: string; display_name: string }[]>`
-      SELECT id, hanablive_username, display_name FROM users WHERE hanablive_username = ${username}
+    const [row] = await sql<{ id: number; display_name: string }[]>`
+      SELECT id, display_name FROM public.users WHERE display_name = ${username}
     `;
     if (!row) {
       res.status(404).json({ error: 'not found' });

--- a/tracker/server/src/routes/tickets.ts
+++ b/tracker/server/src/routes/tickets.ts
@@ -7,6 +7,8 @@ import type {
   GetTicketHistoryResponse,
   TransitionTicketRequest,
   TransitionTicketResponse,
+  UpdateTicketMetadataRequest,
+  UpdateTicketMetadataResponse,
 } from '@tracker/types';
 import { getPool } from '../db/pool.js';
 import {
@@ -15,6 +17,8 @@ import {
   getStatusId,
   searchTickets,
   getTicketHistory,
+  softDeleteTicket,
+  updateTicketMetadata,
 } from '../db/tickets.js';
 import { submitTicket, transitionTicket } from '../services/lifecycle.js';
 import {
@@ -27,6 +31,7 @@ import {
 } from '../db/moderation.js';
 import {
   requireTrackerAuth,
+  optionalTrackerAuth,
   requirePermission,
   type AuthenticatedRequest,
 } from '../middleware/auth.js';
@@ -78,19 +83,20 @@ router.post(
   },
 );
 
-/** GET /tracker/api/tickets — list tickets (paginated) */
+/** GET /tracker/api/tickets — list tickets (paginated); pins sort first for authenticated users */
 router.get(
   '/',
-  requireTrackerAuth,
+  optionalTrackerAuth,
   async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const rawLimit = Number(req.query.limit ?? 25);
     const rawOffset = Number(req.query.offset ?? 0);
     const limit = Number.isInteger(rawLimit) && rawLimit > 0 && rawLimit <= 100 ? rawLimit : 25;
     const offset = Number.isInteger(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
+    const userId = (req as Partial<AuthenticatedRequest>).trackerUser?.id ?? null;
 
     try {
       const sql = getPool();
-      const { tickets, total } = await listTickets(sql, { limit, offset });
+      const { tickets, total } = await listTickets(sql, { limit, offset, userId });
       const body: ListTicketsResponse = { tickets, total, limit, offset };
       res.json(body);
     } catch (err) {
@@ -455,6 +461,74 @@ router.get(
       const history = await getTicketHistory(sql, id);
       const body: GetTicketHistoryResponse = { history };
       res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** PATCH /tracker/api/tickets/:id/metadata — update editable metadata fields */
+router.patch(
+  '/:id/metadata',
+  requireTrackerAuth,
+  requirePermission('ticket.triage'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const id = req.params['id'] as string | undefined;
+    if (!id) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Ticket not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+
+    try {
+      const sql = getPool();
+      const authed = req as AuthenticatedRequest;
+      const input = req.body as UpdateTicketMetadataRequest;
+      const ticket = await updateTicketMetadata(sql, id, input, authed.trackerUser.id);
+      if (!ticket) {
+        res.status(404).json({
+          error: {
+            code: 'NOT_FOUND',
+            message: 'Ticket not found.',
+            correlationId: authed.correlationId,
+          },
+        });
+        return;
+      }
+      const body: UpdateTicketMetadataResponse = ticket;
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/** DELETE /tracker/api/tickets/:id — soft-delete a ticket */
+router.delete(
+  '/:id',
+  requireTrackerAuth,
+  requirePermission('ticket.triage'),
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const id = req.params['id'] as string | undefined;
+    if (!id) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Ticket not found.',
+          correlationId: (req as AuthenticatedRequest).correlationId,
+        },
+      });
+      return;
+    }
+    try {
+      const sql = getPool();
+      await softDeleteTicket(sql, id);
+      res.status(204).end();
     } catch (err) {
       next(err);
     }

--- a/tracker/server/src/services/discord.ts
+++ b/tracker/server/src/services/discord.ts
@@ -24,7 +24,7 @@ interface TicketActorInfo {
 async function fetchTicketActorInfo(
   sql: Sql,
   ticketId: string,
-  actorId: string,
+  actorId: number | null,
 ): Promise<TicketActorInfo | null> {
   const [row] = await sql<TicketActorInfo[]>`
     SELECT
@@ -33,7 +33,7 @@ async function fetchTicketActorInfo(
       s.slug        AS status_slug
     FROM tickets t
     JOIN statuses s ON s.id = t.current_status_id
-    JOIN users    u ON u.id = ${actorId}
+    JOIN public.users u ON u.id = ${actorId}
     WHERE t.id = ${ticketId}
   `;
   return row ?? null;
@@ -69,12 +69,13 @@ function buildPayload(info: TicketActorInfo, eventType: NotificationEventType): 
 export async function sendDiscordWebhook(
   sql: Sql,
   ticketId: string,
-  actorId: string,
+  actorId: number | null,
   eventType: NotificationEventType,
   eventId: string | null,
 ): Promise<void> {
   const webhookUrl = env.DISCORD_MOD_WEBHOOK_URL;
   if (!webhookUrl) return;
+  if (actorId === null) return; // system-triggered events don't send Discord webhooks
 
   try {
     const info = await fetchTicketActorInfo(sql, ticketId, actorId);

--- a/tracker/server/src/services/notifications.ts
+++ b/tracker/server/src/services/notifications.ts
@@ -13,7 +13,7 @@ import { logger } from '../logger.js';
 export async function fanoutNotification(
   sql: Sql,
   ticketId: string,
-  actorId: string,
+  actorId: number | null,
   eventType: NotificationEventType,
 ): Promise<void> {
   try {

--- a/tracker/server/tests/unit/middleware/auth.test.ts
+++ b/tracker/server/tests/unit/middleware/auth.test.ts
@@ -12,11 +12,11 @@ vi.mock('../../../src/db/pool.js', () => ({
   getPool: vi.fn(() => mockSql),
 }));
 
-const mockUpsertTrackerUser = vi.fn<() => Promise<TrackerUserRow>>();
+const mockFindTrackerUser = vi.fn<() => Promise<TrackerUserRow | null>>();
 const mockResolveUserRole = vi.fn<() => Promise<RoleSlug>>();
 
 vi.mock('../../../src/db/users.js', () => ({
-  upsertTrackerUser: mockUpsertTrackerUser,
+  findTrackerUser: mockFindTrackerUser,
   resolveUserRole: mockResolveUserRole,
 }));
 
@@ -102,10 +102,23 @@ describe('requireTrackerAuth', () => {
     expect(errorCode(res)).toBe('UNAUTHORIZED');
   });
 
+  it('returns 401 when user is not found in public.users', async () => {
+    mockFindTrackerUser.mockResolvedValue(null);
+
+    const req = makeReq({ hanabLiveUsername: 'unknown' });
+    const res = makeRes();
+    const next = makeNext();
+
+    await requireTrackerAuth(req, res, next);
+
+    expect(res._status).toBe(401);
+    expect(errorCode(res)).toBe('UNAUTHORIZED');
+    expect(next.called).toBe(false);
+  });
+
   it('returns 403 when account_status is banned', async () => {
-    mockUpsertTrackerUser.mockResolvedValue({
-      id: 'user-1',
-      hanablive_username: 'alice',
+    mockFindTrackerUser.mockResolvedValue({
+      id: 1,
       display_name: 'Alice',
       account_status: 'banned',
     });
@@ -122,9 +135,8 @@ describe('requireTrackerAuth', () => {
   });
 
   it('returns 403 when account_status is restricted', async () => {
-    mockUpsertTrackerUser.mockResolvedValue({
-      id: 'user-1',
-      hanablive_username: 'bob',
+    mockFindTrackerUser.mockResolvedValue({
+      id: 2,
       display_name: 'Bob',
       account_status: 'restricted',
     });
@@ -140,9 +152,8 @@ describe('requireTrackerAuth', () => {
   });
 
   it('attaches trackerUser and calls next() for an active community_member', async () => {
-    mockUpsertTrackerUser.mockResolvedValue({
-      id: 'user-2',
-      hanablive_username: 'carol',
+    mockFindTrackerUser.mockResolvedValue({
+      id: 3,
       display_name: 'Carol',
       account_status: 'active',
     });
@@ -156,15 +167,14 @@ describe('requireTrackerAuth', () => {
 
     expect(next.error).toBeUndefined();
     const trackerUser = (req as unknown as Record<string, unknown>).trackerUser as TrackerUser;
-    expect(trackerUser.id).toBe('user-2');
+    expect(trackerUser.id).toBe(3);
     expect(trackerUser.role).toBe('community_member');
     expect(trackerUser.account_status).toBe('active');
   });
 
   it('uses hanabLiveUsername as displayName fallback when displayName is absent', async () => {
-    mockUpsertTrackerUser.mockResolvedValue({
-      id: 'user-3',
-      hanablive_username: 'dave',
+    mockFindTrackerUser.mockResolvedValue({
+      id: 4,
       display_name: 'dave',
       account_status: 'active',
     });
@@ -176,12 +186,12 @@ describe('requireTrackerAuth', () => {
 
     await requireTrackerAuth(req, res, next);
 
-    expect(mockUpsertTrackerUser).toHaveBeenCalledWith(mockSql, 'dave', 'dave');
+    expect(mockFindTrackerUser).toHaveBeenCalledWith(mockSql, 'dave');
   });
 
   it('calls next(err) when DB throws', async () => {
     const boom = new Error('db error');
-    mockUpsertTrackerUser.mockRejectedValue(boom);
+    mockFindTrackerUser.mockRejectedValue(boom);
 
     const req = makeReq({ hanabLiveUsername: 'eve' });
     const res = makeRes();
@@ -200,7 +210,7 @@ describe('requirePermission', () => {
     const req = {} as unknown as Record<string, unknown>;
     if (role !== undefined) {
       req.trackerUser = {
-        id: 'u',
+        id: 1,
         hanablive_username: 'x',
         display_name: 'X',
         account_status: 'active',

--- a/tracker/server/tests/unit/security.test.ts
+++ b/tracker/server/tests/unit/security.test.ts
@@ -21,7 +21,7 @@ const app = createApp();
 const PROTECTED_ROUTES: [string, string][] = [
   // Tickets
   ['post', '/tracker/api/tickets'],
-  ['get', '/tracker/api/tickets'],
+  // GET /tracker/api/tickets is public (optionalTrackerAuth) — no 401
   ['get', '/tracker/api/tickets/ready-for-review'],
   ['get', '/tracker/api/tickets/planning-signal'],
   ['get', '/tracker/api/tickets/search?q=test'],
@@ -34,7 +34,7 @@ const PROTECTED_ROUTES: [string, string][] = [
   // Discussion (mounted under /tracker/api/tickets/:ticketId)
   ['get', '/tracker/api/tickets/00000000-0000-0000-0000-000000000001/comments'],
   ['post', '/tracker/api/tickets/00000000-0000-0000-0000-000000000001/comments'],
-  ['get', '/tracker/api/tickets/00000000-0000-0000-0000-000000000001/votes'],
+  // GET .../votes is public (optionalTrackerAuth) — no 401
   ['post', '/tracker/api/tickets/00000000-0000-0000-0000-000000000001/votes'],
   // Me
   ['get', '/tracker/api/me/notifications'],


### PR DESCRIPTION
## Summary

- **Backend**: `PATCH /:id/metadata` and `DELETE /:id` routes (both require `ticket.triage` permission); `updateTicketMetadata` uses a CTE to atomically update tickets and insert into `ticket_metadata_history`; `softDeleteTicket` sets `deleted_at`; filtered from all list/detail queries
- **Migrations**: ticket pins (20260329), public users join (20260330), soft delete + metadata history (20260404)
- **Role resolution**: `resolveUserRole` now falls back to `public.users.roles` so SUPERADMIN/SITE_ADMIN get `committee`-level tracker access without a manual DB row
- **Frontend**: mod sidebar on FeedbackDetailPage (status transition with resolution note, metadata editor, delete with confirmation modal); `isMod` derived from `useAuth().user.roles` — no `/tracker/api/me` call; `TicketHistoryEntry` is now a proper discriminated union on `kind`

## Test plan

- [ ] Log in as SUPERADMIN — mod sidebar should appear on ticket detail
- [ ] Log in as regular user — no mod sidebar
- [ ] Status transition: select a valid next status, submit; history row appears
- [ ] Terminal status (decided/rejected/closed): resolution note field appears and is required
- [ ] Metadata edit: change type/domain/severity/reproducibility; history row appears
- [ ] Delete ticket: confirm modal, ticket disappears from list
- [ ] Deleted ticket URL returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)