### PR TITLE
fix(ci): MarkdownRenderer null crash, tracker unit env, and CI database URL

### DIFF
--- a/.github/workflows/ci-battery.yml
+++ b/.github/workflows/ci-battery.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           echo "JWT_SECRET=test_jwt_secret_for_ci" >> $GITHUB_ENV
           echo "DATABASE_URL=postgresql://hanabi_user:hanabi_password@localhost:55432/hanabi_test" >> $GITHUB_ENV
+          echo "TRACKER_DATABASE_URL=postgresql://hanabi_user:hanabi_password@localhost:55432/hanabi_test" >> $GITHUB_ENV
           echo "NODE_ENV=test" >> $GITHUB_ENV
 
       - name: Run CI test battery

--- a/apps/web/src/ui/MarkdownRenderer.tsx
+++ b/apps/web/src/ui/MarkdownRenderer.tsx
@@ -330,7 +330,7 @@ type ParsedMarkdown = { tree: Root; definitions: DefinitionsMap };
 
 let lastParsed: { markdown: string; parsed: ParsedMarkdown } | null = null;
 function parseMarkdown(markdown: string): ParsedMarkdown {
-  if (lastParsed?.markdown === markdown) return lastParsed.parsed;
+  if (lastParsed !== null && lastParsed.markdown === markdown) return lastParsed.parsed;
 
   const parsedTree = applyTypographyReplacements(
     unified().use(remarkParse).use(remarkGfm).parse(replaceEmojiShortcodes(markdown)) as Root,

--- a/tracker/server/vitest.unit.config.ts
+++ b/tracker/server/vitest.unit.config.ts
@@ -5,5 +5,10 @@ export default mergeConfig(baseConfig, {
   test: {
     include: ['tests/unit/**/*.test.ts'],
     exclude: ['tests/integration/**'],
+    env: {
+      // Satisfy env validation at import time; unit tests never connect to the DB
+      TRACKER_DATABASE_URL: 'postgresql://localhost:5432/tracker_unit_test',
+      JWT_SECRET: 'unit-test-secret',
+    },
   },
 });


### PR DESCRIPTION
Fixes the three issues causing PR #97 CI to fail.

## Changes

- **MarkdownRenderer**: `lastParsed?.markdown === markdown` evaluates to `true` when both are `undefined` (module-level `lastParsed` starts as `null`, optional-chain returns `undefined`), then `lastParsed.parsed` throws. Guard with `lastParsed !== null` check.
- **tracker vitest.unit.config.ts**: Add `env` stubs so `TRACKER_DATABASE_URL` env validation passes at import time without a `.env` file in CI.
- **ci-battery.yml**: Add `TRACKER_DATABASE_URL` to the env step so tracker integration tests can connect to the test database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)